### PR TITLE
Correct scroll direction in OS X.

### DIFF
--- a/src/pyglet/window/cocoa/pyglet_view.py
+++ b/src/pyglet/window/cocoa/pyglet_view.py
@@ -9,8 +9,8 @@ NSTrackingArea = ObjCClass('NSTrackingArea')
 
 def getMouseDelta(nsevent):
     dx = nsevent.deltaX()
-    dy = -nsevent.deltaY()
-    return int(round(dx)), int(round(dy))
+    dy = nsevent.deltaY()
+    return dx, dy
 
 def getMousePosition(self, nsevent):
     in_window = nsevent.locationInWindow()


### PR DESCRIPTION
Scroll direction is reversed in pyglet, in contrast to other applications.