### PR TITLE
蓝的极智与巫女服的结算

### DIFF
--- a/src/gamepack/thb/cards/equipment.py
+++ b/src/gamepack/thb/cards/equipment.py
@@ -432,10 +432,21 @@ class MaidenCostumeSkill(ShieldSkill):
     skill_category = ('equip', 'passive')
 
 
-class MaidenCostumeEffect(spellcard.NonResponsiveInstantSpellCardAction):
+class MaidenCostumeEffect(spellcard.SinsackCarnivalEffect):
+    @property
+    def non_responsive(self):
+        return self.target.has_skill(MaidenCostumeSkill)
+
     def apply_action(self):
         g = Game.getgame()
-        g.process_action(Damage(source=self.source, target=self.target))
+        src, tgt = self.source, self.target
+        
+        if tgt.has_skill(MaidenCostumeSkill):
+            g.process_action(Damage(src, tgt))
+
+        else:
+            return super(MaidenCostumeEffect, self).apply_action()
+
         return True
 
 
@@ -448,11 +459,9 @@ class MaidenCostumeHandler(EventHandler):
         if evt_type == 'action_before' and isinstance(act, spellcard.SinsackCarnivalEffect):
             target = act.target
             if not act.cancelled and target.has_skill(MaidenCostumeSkill):
-                act.cancelled = True
-                nact = MaidenCostumeEffect(source=act.source, target=target)
-                nact.associated_card = act.associated_card
-                return nact
-                # Game.getgame().process_action(nact)
+                act.__class__ = classmix(MaidenCostumeEffect, act.__class__)
+                return act
+
         return act
 
 

--- a/src/gamepack/thb/cards/spellcard.py
+++ b/src/gamepack/thb/cards/spellcard.py
@@ -16,14 +16,10 @@ from utils import BatchList, CheckFailed, check, flatten
 
 # -- code --
 class SpellCardAction(UserAction):
-    pass
+    non_responsive = False
 
 
 class InstantSpellCardAction(SpellCardAction):
-    pass
-
-
-class NonResponsiveInstantSpellCardAction(InstantSpellCardAction):
     pass
 
 
@@ -77,7 +73,7 @@ class RejectHandler(EventHandler):
     def handle(self, evt_type, act):
         if evt_type == 'action_before' and isinstance(act, SpellCardAction):
             if act.cancelled: return act  # some other thing have done the job
-            if isinstance(act, NonResponsiveInstantSpellCardAction):
+            if act.non_responsive:
                 return act
 
             g = Game.getgame()


### PR DESCRIPTION

场景①：蓝的上家使用了罪袋狂欢，对蓝造成伤害。


场景②：蓝弃置巫女服发动了极智。


场景③：游戏结束。


极智：你的回合外，当有非延时符卡的效果对一名角色生效后，你可以弃置一张牌使该效果对该角色重新进行一次结算，此时效果来源视为你。每轮限一次。



巫女服：装备后：你无法响应【罪袋狂欢】。



结算①：蓝装备有巫女服，无法响应【罪袋狂欢】。


结算②：蓝发动极智，弃置了巫女服，再次结算【罪袋狂欢】。


结算③：蓝没有装备巫女服，可以响应【罪袋狂欢】。



问题：蓝极智之后，仍然无法响应【罪袋狂欢】。

By：木子化十