### PR TITLE
Request: YinYangOrb fatetell, taken out of card migration

### DIFF
--- a/src/thb/cards/equipment.py
+++ b/src/thb/cards/equipment.py
@@ -915,8 +915,8 @@ class YinYangOrb(GenericAction):
                 with MigrateCardsTransaction(self) as trans:
                     migrate_cards([ft.card], tgt.cards, unwrap=True, trans=trans, is_bh=True)
                     detach_cards([e], trans=trans)
-                    self.card = e
-                    ft.set_card(e, self)
+                self.card = e
+                ft.set_card(e, self)
 
                 break
         else:


### PR DESCRIPTION
It is a subtle bug to fix that when Tenshi percept, she can take YinYangOrb regardless of whether the equipment is really detached or not. The fatetelling result must be given after the codes come out of the "with as" transaction which ensures equipment cards are truly detached at the end of using Orb to change fatetell results.