### PR TITLE
Prevention for Crash by Demolition spellcard

### DIFF
--- a/src/thb/cards/spellcard.py
+++ b/src/thb/cards/spellcard.py
@@ -29,6 +29,7 @@ class Demolition(InstantSpellCardAction):
         g = Game.getgame()
         src, tgt = self.source, self.target
 
+        if not (tgt.cards or tgt.showncards or tgt.equips or tgt.fatetell): return False
         catnames = ('cards', 'showncards', 'equips', 'fatetell')
         cats = [getattr(tgt, i) for i in catnames]
         card = user_input([src], ChoosePeerCardInputlet(self, tgt, catnames))


### PR DESCRIPTION
When Demolition aims at target, it has been judged whether target has any card in 4 card zones; nevertheless, whence target launches Reject which is again rejected, demolition really takes effect at a target with no cards at all, the game collapses. This corner condition is now prevented, once and for all.