### PR TITLE
Request: Add restriction on FreakingPower

### DIFF
--- a/src/thb/characters/yugi.py
+++ b/src/thb/characters/yugi.py
@@ -92,6 +92,8 @@ class FreakingPowerHandler(EventHandler):
         elif evt_type == 'action_after' and isinstance(act, Damage):
             g = Game.getgame()
 
+            if act.cancelled: return act
+            
             pact = g.action_stack[-1]
             if not marked(pact, 'freaking_power'):
                 return act


### PR DESCRIPTION
Once Yugi with RepentanceStick launches atk but cancels damage, she will be able to drop 3 cards from the target, which is subtly different from descriptions showing that she can only exert freakingpower to drop cards after real damage is done.