### PR TITLE
 Adjustment of Youmu's Vatality

### DIFF
--- a/src/thb/characters/youmu.py
+++ b/src/thb/characters/youmu.py
@@ -109,7 +109,7 @@ class YoumuHandler(EventHandler):
                 n = self.weapons(p)
                 dn = len(cards)
 
-                if cl is _from and (dn + n) >= 2 and n <= 1:
+                if cl is _from and (dn + n) >= 2 and n <= 1 and any(getattr(c, 'equipment_category', None) == 'weapon' for c in cards):
                     adjust = -1
                 elif cl is to and (n - dn) <= 1 and n >= 2:
                     adjust = 1


### PR DESCRIPTION
Consider the situation as follows: Youmu tries to put on a new UFO or suit, replacing the former one, which drops non-weapon equip, then dn+n>=2, (weapon not lost), she will lose necessary vitality. Here cards in dn shall be tested with a bool judging whether any weapons are among them.