### PR TITLE
When Reisen's Disard takes effect, any card treated as (the real laun…

### DIFF
--- a/src/thb/characters/reisen.py
+++ b/src/thb/characters/reisen.py
@@ -86,16 +86,11 @@ class DiscarderHandler(EventHandler):
             if src is not g.current_player: return act
 
             self.card = c = act.card
-            if not c.is_card(PhysicalCard):
-                vc = getattr(c, 'treat_as', False)
-                if vc:
-                    if issubclass(vc, AttackCard):
-                        return act
-                    else:
-                        raise DiscarderAttackOnly
+            if not c.is_card(AttackCard):
+                if c.is_card(PhysicalCard) or 'treat_as' in c.category:
+                    raise DiscarderAttackOnly
                 else:
                     return act
-            if not c.is_card(AttackCard): raise DiscarderAttackOnly
 
             dist = LaunchCard.calc_distance(src, Discarder(src))
             dist.pop(src, '')

--- a/src/thb/characters/reisen.py
+++ b/src/thb/characters/reisen.py
@@ -86,7 +86,15 @@ class DiscarderHandler(EventHandler):
             if src is not g.current_player: return act
 
             self.card = c = act.card
-            if not c.is_card(PhysicalCard): return act
+            if not c.is_card(PhysicalCard):
+                vc = getattr(c, 'treat_as', False)
+                if vc:
+                    if issubclass(vc, AttackCard):
+                        return act
+                    else:
+                        raise DiscarderAttackOnly
+                else:
+                    return act
             if not c.is_card(AttackCard): raise DiscarderAttackOnly
 
             dist = LaunchCard.calc_distance(src, Discarder(src))


### PR DESCRIPTION
It shall be underlined that according to Spell Card Rule, once `physical X` is launched being `treated as` VC Y, i.e. Harvest, Grimoire and so on, the card Launched is `Y`, VC. Once I talked that openly on whether to reduce Reisen's Discard's description to "the victim can use none but physical ones at hand". We take it as a common sense that we shall factually Make Reisen Great Again as the Reisen debuff nowadays is too weak to let users choose her.
In addition, this change ver takes not disabling skills not really launching card (in program it launches as ASLC, but `launching` no Physical Object's `associated_action`, merely wrapped skills with card sending or dropping) into consideration. Only `VC` with `treat_as` and NOT `treated as AtkCard` shall get stopped by action limit, M.E.C.E., according to spellcard rule.