### PR TITLE
Rumia: fix KOF Darkness malfunction

### DIFF
--- a/src/thb/characters/rumia.py
+++ b/src/thb/characters/rumia.py
@@ -112,7 +112,7 @@ class DarknessKOFHandler(EventHandler):
                 return arg
 
             card = arg.card
-            if not card.is_card(PhysicalCard):
+            if not card.is_card(PhysicalCard) and 'treat_as' not in card.category:
                 return arg
 
             if card.is_card(RejectCard):


### PR DESCRIPTION
Rumia: Fix darkness malfunction
Still working on problems of VC and TreatAs. In aya's skill -> treat_as, block 1 -> 0; in melancholy limit, block all skills, walk all cards; these work well. Rumia shall also block being chosen as tgt of vc with treat_as.
