### PR TITLE
Clarification of skill: temporary [out of game] cardlist description

### DIFF
--- a/src/thb/ui/ui_meta/characters/momiji.py
+++ b/src/thb/ui/ui_meta/characters/momiji.py
@@ -47,7 +47,7 @@ class Telegnosis:
 class Disarm:
     # Skill
     name = u'缴械'
-    description = u'每当你使用|G弹幕|r或|G弹幕战|r对其他角色造成伤害后，你可以观看其手牌，并将其中所有的|G弹幕|r与符卡牌暂时移出游戏。该角色被暂时移出的牌会在该角色下一个弃牌阶段后归还回其手牌中。'
+    description = u'每当你使用|G弹幕|r或|G弹幕战|r对其他角色造成伤害后，你可以观看其手牌，并将其中任意数量的|G弹幕|r或符卡牌暂时移出游戏。该角色被暂时移出的牌会在该角色下一个弃牌阶段后归还回其手牌中。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid

--- a/src/thb/ui/ui_meta/characters/momiji.py
+++ b/src/thb/ui/ui_meta/characters/momiji.py
@@ -47,7 +47,7 @@ class Telegnosis:
 class Disarm:
     # Skill
     name = u'缴械'
-    description = u'每当你使用|G弹幕|r或|G弹幕战|r对其他角色造成伤害后，你可以观看其手牌，并将其中任意数量的|G弹幕|r或符卡牌暂时移出游戏。'
+    description = u'每当你使用|G弹幕|r或|G弹幕战|r对其他角色造成伤害后，你可以观看其手牌，并将其中所有的|G弹幕|r与符卡牌暂时移出游戏。该角色被暂时移出的牌会在该角色下一个弃牌阶段后归还回其手牌中。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid

--- a/src/thb/ui/ui_meta/characters/momiji.py
+++ b/src/thb/ui/ui_meta/characters/momiji.py
@@ -119,7 +119,7 @@ class SolidShieldAction:
 class SolidShield:
     # Skill
     name = u'坚盾'
-    description = u'你距离1以内的角色成为其它角色使用的|G弹幕|r或单体符卡的目标后，若此卡牌为其出牌阶段时使用的第一张卡牌，取消之并暂时移出游戏。'
+    description = u'你距离1以内的角色成为其它角色使用的|G弹幕|r或单体符卡的目标后，若此卡牌为其出牌阶段时使用的第一张卡牌，取消之并暂时移出游戏。该角色被暂时移出的牌会在该角色下一个弃牌阶段后归还回其手牌中。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid

--- a/src/thb/ui/ui_meta/characters/yukari.py
+++ b/src/thb/ui/ui_meta/characters/yukari.py
@@ -15,7 +15,7 @@ __metaclass__ = gen_metafunc(characters.yukari)
 class SpiritingAway:
     # Skill
     name = u'神隐'
-    description = u'出牌阶段限两次，你可以将场上的一张牌暂时移出游戏。你可以观看以此法移出游戏的牌。'
+    description = u'出牌阶段限两次，你可以将场上的一张牌暂时移出游戏。你可以观看以此法移出游戏的牌。该角色被紫暂时移出的牌会在紫的结束阶段后归还回该角色的手牌中。'
 
     def clickable(game):
         me = game.me


### PR DESCRIPTION
Consider an instance: Yukari tries to spirit away 2 cards (maybe very valuable equip) of an enemy character, and then she launches Exinwan which results in her fall by herself before finalize stage; however, the 2 cards that are expected to be returned to enemy's cardlist, will be excluded from the game's cardlists forever (2 cards are destroyed). After discussion, users reach a consensus that all right for yukari's powerful skill, but words on skills are too misleading to cope with such situations.
Complaints argue that some descriptions are unfriendly to new users and skill descriptions of Yukari, Momiji are not clear enough so as to let all users evaluate the true strengths and weaknesses of the characters involved. Once I dismissed these complaints, nonetheless, when the situation told before comes to reality, there will be some arguments on it.