### PR TITLE
Overall Fix of Alice and Shinmyoumaru conflict; Reenable PCMT; Add re…

### DIFF
--- a/src/thb/characters/alice.py
+++ b/src/thb/characters/alice.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 # -- own --
 from game.autoenv import EventHandler, Game, user_input
 from thb.actions import ActionStage, Damage, DrawCards, DropCardStage, DropCards
-from thb.actions import GenericAction, LaunchCard, PlayerTurn, MigrateCardsTransaction
+from thb.actions import GenericAction, LaunchCard, PlayerTurn, PostCardMigrationHandler
 from thb.actions import Reforge, UserAction, mark, marked, random_choose_card
 from thb.actions import user_choose_cards, user_choose_players
 from thb.cards import AttackCard, DollControlCard, Heal, Skill, TreatAs, VirtualCard
@@ -219,17 +219,11 @@ class DollBlastHandlerCommon(object):
 
 class DollBlastMigrationHandler(DollBlastHandlerCommon, EventHandler):
     interested = ('post_card_migration',)
+    group = PostCardMigrationHandler
 
-    def handle(self, evt_type, trans):
-        if evt_type == 'post_card_migration' and isinstance(trans, MigrateCardsTransaction):
-            pl = [p for p in Game.getgame().players if p.has_skill(DollBlast) and not p.dead]
-            assert len(pl) <= 1
-            if pl:
-                p = pl[0]
-            else:
-                return trans
-        else:
-            return trans
+    def handle(self, p, trans):
+        if not p.has_skill(DollBlast) or p.dead:
+            return True
 
         equips = p.equips
 
@@ -250,7 +244,7 @@ class DollBlastMigrationHandler(DollBlastHandlerCommon, EventHandler):
 
             self.fire(p, tgt, cl)
 
-        return trans
+        return True
 
 
 class DollBlastDropHandler(DollBlastHandlerCommon, EventHandler):

--- a/src/thb/characters/alice.py
+++ b/src/thb/characters/alice.py
@@ -266,7 +266,8 @@ class DollBlastDropHandler(DollBlastHandlerCommon, EventHandler):
             mark(act, 'doll_blast')
 
         elif evt_type == 'action_after' and isinstance(act, DropCards) and marked(act, 'doll_blast'):
-            self.fire(act.target, act.source, act.cards)
+            if tgt.has_skill(DollBlast):
+                self.fire(act.target, act.source, act.cards)
 
         return act
 

--- a/src/thb/characters/shinmyoumaru.py
+++ b/src/thb/characters/shinmyoumaru.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 # -- third party --
 # -- own --
 from game.autoenv import EventHandler, Game, user_input
-from thb.actions import Damage, DropCards, FatetellAction, FatetellMalleateHandler
+from thb.actions import Damage, DropCards, FatetellAction, FatetellMalleateHandler, PostCardMigrationHandler
 from thb.actions import MigrateCardsTransaction, UseCard, detach_cards
 from thb.actions import migrate_cards, user_choose_cards
 from thb.cards import Skill, t_None
@@ -93,20 +93,14 @@ class VengeOfTsukumogamiAction(FatetellAction):
 
 class VengeOfTsukumogamiHandler(EventHandler):
     interested = ('post_card_migration',)
+    group = PostCardMigrationHandler
 
-    def handle(self, evt_type, trans):
-        if evt_type == 'post_card_migration' and isinstance(trans, MigrateCardsTransaction):
-            pl = [p for p in Game.getgame().players if p.has_skill(VengeOfTsukumogami) and not p.dead]
-            assert len(pl) <= 1
-            if pl:
-                p = pl[0]
-            else:
-                return trans
-        else:
-            return trans
+    def handle(self, p, trans):
+        if not p.has_skill(VengeOfTsukumogami) or p.dead:
+            return True
 
         if not isinstance(trans.action, DropCards):
-            return trans
+            return True
 
         for cards, _from, to, is_bh, _ in trans.get_movements():
             if _from is None or _from.type != 'equips':
@@ -130,7 +124,7 @@ class VengeOfTsukumogamiHandler(EventHandler):
 
                 Game.getgame().process_action(VengeOfTsukumogamiAction(p, tgt, c))
 
-        return trans
+        return True
 
 
 @register_character_to('common')


### PR DESCRIPTION
1) Why reenable PCMT?
Once I thought the anticlockwise order is no longer suitable for this situation (or also responsible for a huge bug), but now it seems very useful, and in the time to come, if to solve conflicts among more event handlers, this "group" idea will definetely satiate needs of anticlockwise principle. Reenable it.

2) What really happened to Alice and Shinmyoumaru?
The real problem lies in 2 files (2 classes). To begin with, in the test sequence of Alice's dollblast, there's "if has skill" restriction, which seems to ensure that if p.dead, has_skill shall return False, but things turn out to be on the contrary: p.dead -> 1, but has_skill -> 0, which comes from the design of PlayerDeath cls. In 2v2, Heritage handler comes instantly after the DeadDropCards, which is between the 2 handle_single_event of PCMT. As a result, when has_skill goes through DollBlast's test sequence, p.dead -> 1 but has_skill -> 0, therefore Alice can launch the DollBlast even after "it seems that she has already fallen". I changed the order of DeadDropCards and p.dead = 1, has_skills = [], to prevent some potential bugs; also, sending "not p.dead" into test sequence of both Shinmyoumaru and Alice, will make ehs more robust for challenges to come.
There are no more questions or disputes. In daiyousei SupportKOF, evt_type == 'action_apply' and isinstance(arg, PlayerDeath) is the trigger of saving cards. While During PlayerDeath, action = self.emit_event('action_apply', action) comes earlier than try: rst = action.apply_action(), so the PlayerDeath hasn't cleared all skills yet, daiyousei is still able to save cards and give to next character.
Surgical changes merely, like that in YinYangOrb.

3) What's solution for some not anticlockwise conflicts in the future?
It is known that the game itself is driven by EH sequences in a list which dominates all events, char, card, equip and even game_eh like Dying, Shuffle, and so on. It turns out impossible to normalize all these into a so-called [from current player anticlockwise order] which goes over all cards, equips and char in the game, and also NOT NECESSARY.
From the perspective of time & space complexity, a new method of eh order is not better than the current one. The [get_relevant_eh] goes in a loop of 140-150 ehs, < 300 times; than it PICKS OUT ones [interested] in the current emitted event, deal with them, in total 5~10 * n times where n is length of test sequence of [handle()]; while the anticlockwise test may spend 8 * 4 * n (all ones on field, order of char first + equip second). The difference in space cost is even more obvious, each time the sgsOL code takes almost 30 to 32 ehs to undergo one event, while THB takes only 5 to 10 interested ones to test in one EH dealing section.
In addition, the mechanism in THB eh dealing, has unneglectable edge over that in sgsOL, in the perspective of high cohesion and low coupling. If to loop all field ehs (cannot each time each second update the EHs on field, which adds to time consumption), once an event is emitted, everyone on the field gets stimulated, it makes all eh classes exposed to emit_event, which increases the risk of explosion of bugs. Picking out the specific EHs may make the potential bugs FEWER, the coupling between the modules LOWER. It's no better idea to remain the present EHs order and keep that toposorted make_list() clsmethod which updates eh orders only when new characters come to stage.
Nonetheless, this tradition (everything driven by [indifferent EHs]) causes UNEXPLAINABLE but NOT SEVERE problems if and only if once some characters' skills can be triggered by THIRD PARTY BEHAVIOR. For instance, Shinmyoumaru and Kaguya, their EHs are interested in characters that are none-of-their own business, neither involving herself as src or tgt. If to set rules and declare to public users that "hey we are truly anticlockwise!", then ok, first, active action player (src); second, next, passive tgt; then, if there are >= 2 third party listeners for this event emission, their order cannot get explained. At present, NOT A SINGLE character minds others' business like that, like someone neither attacked nor damaged, but can react on damage events. Therefore, from now on, designs of skills can never reach their minds too long to interfere with other 2 characters BILATERAL AFFAIRS that may cause an unexplainable order mess; also, the [evt_type == Atk or Dmg] are malleated with WineHandlers, CalcDistance and some other handlers, which allows no interference from skill's eh. Once any more conflicts come (new char), the program can add one line [emit_event('post_damage', self)], then follow the anticlockwise rule by PostCardMigrationHandler. For more instance, the current Ran can do EI earlier than Medicine's poison, is according to a rule that current_player first; but once a LONG ARM THIRD PARTY EH came to disturb order, just do another Transaction to handle them one by one. Anyhow, the present problem is just changing orders between weapons and char eh, changing Reimu's Clear and Tenshi, Shiki, and so on, all little changes.
To conclude, it seems that discussion on a consistent and extensive rule of SAME TIME SAME EVENT multi-EH is better to improve the mechanism. Toposorted list is the benchmark, dealing with game_eh and char, equip, card ehs; and whence unsolvable conditions come, it is also possible to add a new [emit_event('new_event', self)] and Make [group = NewTransaction] to end disputes. Last but not least, this discussion creates a guideline to debug, in the times to follow.

Discussion on order mess is closed. The principle is fixing bugs shall never generate new bugs.
So hard... (>_<)