### PR TITLE
Fix Nensha to fit description; imitate ayafan; 4 lines on dmg overrid…

### DIFF
--- a/src/thb/cards/equipment.py
+++ b/src/thb/cards/equipment.py
@@ -301,18 +301,20 @@ class NenshaPhoneHandler(EventHandler):
     interested = ('action_after',)
 
     def handle(self, evt_type, act):
-        from .basic import BaseAttack
-        if not evt_type == 'action_after': return act
-        if not isinstance(act, BaseAttack): return act
-        if not act.succeeded: return act
-        src = act.source
-        tgt = act.target
-        if tgt.dead: return act
-        if not tgt.cards: return act
-        if not src.has_skill(NenshaPhoneSkill): return act
-        if not user_input([src], ChooseOptionInputlet(self, (False, True))): return act
-        g = Game.getgame()
-        g.process_action(NenshaPhone(src, tgt))
+        if evt_type == 'action_after' and isinstance(act, Damage):
+            if not act.succeeded: return act
+            g = Game.getgame()
+            pa = g.action_stack[-1]
+            if not isinstance(pa, basic.BaseAttack): return act
+
+            src = act.source
+            tgt = act.target
+            if tgt.dead: return act
+            if not tgt.cards: return act
+            if not src.has_skill(NenshaPhoneSkill): return act
+            if not user_input([src], ChooseOptionInputlet(self, (False, True))): return act
+            g.process_action(NenshaPhone(src, tgt))
+
         return act
 
 


### PR DESCRIPTION
Nensha Phone's description makes it work only after dmg, instead of a successful atk.
To fit description: described as "after dmg".
Fixed bug: SP Flandre's four of a kind encountered with NenshaPhone, SP Flandre prevents the dmg, atk not cancelled but also succeeded, Nensha may see card. Fixed, same time and condition like that in ayafan.

(>_<) It seems THB 2017 ver 30 bugs are almost done...