### PR TITLE
Fix bug: Mad Sinsack in KOF

### DIFF
--- a/src/thb/cards/spellcard.py
+++ b/src/thb/cards/spellcard.py
@@ -221,6 +221,9 @@ class Sinsack(DelayedSpellCardAction, FatetellAction):
                     migrate_cards([self.associated_card], pl[next].fatetell)
                     return
                 next += 1
+            if next == stop and len(pl) == 2:
+                migrate_cards([self.associated_card], pl[next-1].fatetell)
+                return
 
 
 class YukariDimension(InstantSpellCardAction):


### PR DESCRIPTION
Recently one mad sinsack changed by exinwan from shiki (which directly results the fall of shiki) in KOF triggered a rarely seen bug.
If and only if in KOF, shiki falls within another one's fatetellstage, sinsakck stays in ft zone like it never finished till it succeeds.
Here give a specific "if next == stop and len(pl) == 2" outside while loop: always move it away.

Unstoppable sinsack ft report: http://www.thbattle.net/thread-81153-1-1.html
