### PR TITLE
Order fix of after damage: activechar>weapon>passivechar, some are no…

### DIFF
--- a/src/thb/cards/equipment.py
+++ b/src/thb/cards/equipment.py
@@ -299,11 +299,6 @@ class NenshaPhone(GenericAction):
 @register_eh
 class NenshaPhoneHandler(EventHandler):
     interested = ('action_after',)
-    execute_before = (
-        'MajestyHandler',
-        'MasochistHandler',
-        'MelancholyHandler',
-    )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_after' and isinstance(act, Damage):
@@ -736,11 +731,6 @@ class AyaRoundfanSkill(WeaponSkill):
 @register_eh
 class AyaRoundfanHandler(EventHandler):
     interested = ('action_after',)
-    execute_before = (
-        'DecayDamageHandler',
-        'DilemmaHandler',
-        'EchoHandler',
-    )
     card_usage = 'drop'
 
     def handle(self, evt_type, act):

--- a/src/thb/cards/equipment.py
+++ b/src/thb/cards/equipment.py
@@ -299,6 +299,11 @@ class NenshaPhone(GenericAction):
 @register_eh
 class NenshaPhoneHandler(EventHandler):
     interested = ('action_after',)
+    execute_before = (
+        'MajestyHandler',
+        'MasochistHandler',
+        'MelancholyHandler',
+    )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_after' and isinstance(act, Damage):
@@ -474,7 +479,6 @@ class IbukiGourdSkill(RedUFOSkill):
 @register_eh
 class IbukiGourdHandler(EventHandler):
     interested = ('action_apply', 'action_after', 'card_migration')
-    execute_after = ('WineHandler', )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_after' and isinstance(act, Damage):
@@ -732,7 +736,11 @@ class AyaRoundfanSkill(WeaponSkill):
 @register_eh
 class AyaRoundfanHandler(EventHandler):
     interested = ('action_after',)
-    execute_after = ('DyingHandler',)
+    execute_before = (
+        'DecayDamageHandler',
+        'DilemmaHandler',
+        'EchoHandler',
+    )
     card_usage = 'drop'
 
     def handle(self, evt_type, act):

--- a/src/thb/characters/cirno.py
+++ b/src/thb/characters/cirno.py
@@ -125,7 +125,6 @@ class PerfectFreezeHandler(EventHandler):
 
     execute_after = (
         'RepentanceStickHandler',
-        'AyaRoundfanHandler',
     )
 
     def handle(self, evt_type, act):

--- a/src/thb/characters/kaguya.py
+++ b/src/thb/characters/kaguya.py
@@ -61,7 +61,11 @@ class DilemmaHealAction(DrawCards):
 
 class DilemmaHandler(EventHandler):
     interested = ('action_after',)
-    execute_after = ('DyingHandler', )
+    execute_after = (
+        'DyingHandler',
+        'AyaRoundfanHandler',
+        'NenshaPhoneHandler',
+    )
 
     def handle(self, evt_type, act):
         if evt_type != 'action_after': return act

--- a/src/thb/characters/kyouko.py
+++ b/src/thb/characters/kyouko.py
@@ -31,6 +31,11 @@ class EchoAction(UserAction):
 
 class EchoHandler(EventHandler):
     interested = ('action_after',)
+    execute_after = (
+        'DyingHandler',
+        'AyaRoundfanHandler',
+        'NenshaPhoneHandler',
+    )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_after' and isinstance(act, Damage):

--- a/src/thb/characters/medicine.py
+++ b/src/thb/characters/medicine.py
@@ -104,6 +104,11 @@ class MelancholyAction(GenericAction):
 
 class MelancholyHandler(EventHandler):
     interested = ('action_after', 'action_shootdown')
+    execute_after = (
+        'DyingHandler',
+        'AyaRoundfanHandler',
+        'NenshaPhoneHandler',
+    )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_after' and isinstance(act, Damage):

--- a/src/thb/characters/momiji.py
+++ b/src/thb/characters/momiji.py
@@ -45,6 +45,7 @@ class DisarmReturningAction(GenericAction):
 class DisarmHandler(EventHandler):
     interested = ('action_after',)
     execute_after = ('DyingHandler',)
+    execute_before = ('AyaRoundfanHandler',)
 
     card_usage = 'launch'
 

--- a/src/thb/characters/reimu.py
+++ b/src/thb/characters/reimu.py
@@ -229,15 +229,18 @@ class ReimuClearAction(UserAction):
 class ReimuClearHandler(EventHandler):
     interested = ('action_after',)
     execute_before = (
-        'MasochistHandler',
+        'AyaRoundfanHandler',
+        'NenshaPhoneHandler',
+        'DilemmaHandler',
         'DecayDamageHandler',
+        'EchoHandler',
         'MelancholyHandler',
+        'MajestyHandler',
+        'MasochistHandler',
     )
 
     execute_after = (
         'IbukiGourdHandler',
-        'AyaRoundfanHandler',
-        'MajestyHandler',
     )
 
     def handle(self, evt_type, act):

--- a/src/thb/characters/shikieiki.py
+++ b/src/thb/characters/shikieiki.py
@@ -85,6 +85,11 @@ class MajestyAction(UserAction):
 
 class MajestyHandler(EventHandler):
     interested = ('action_after',)
+    execute_after = (
+        'DyingHandler',
+        'AyaRoundfanHandler',
+        'NenshaPhoneHandler',
+    )
 
     def handle(self, evt_type, act):
         if not evt_type == 'action_after': return act

--- a/src/thb/characters/shizuha.py
+++ b/src/thb/characters/shizuha.py
@@ -153,7 +153,12 @@ class DecayEffect(UserAction):
 
 class DecayDamageHandler(EventHandler):
     interested = ('action_after', 'action_before')
-    execute_after = ('SuwakoHatHandler', )
+    execute_after = (
+        'DyingHandler',
+        'AyaRoundfanHandler',
+        'NenshaPhoneHandler',
+        'SuwakoHatHandler',
+    )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_after' and isinstance(act, Damage):

--- a/src/thb/characters/tenshi.py
+++ b/src/thb/characters/tenshi.py
@@ -63,6 +63,11 @@ class MasochistAction(UserAction):
 
 class MasochistHandler(EventHandler):
     interested = ('action_after',)
+    execute_after = (
+        'DyingHandler',
+        'AyaRoundfanHandler',
+        'NenshaPhoneHandler',
+    )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_after' and isinstance(act, Damage):

--- a/src/thb/characters/yugi.py
+++ b/src/thb/characters/yugi.py
@@ -79,6 +79,7 @@ class FreakingPowerAction(FatetellAction):
 
 class FreakingPowerHandler(EventHandler):
     interested = ('action_after', 'action_before', )
+    execute_before = ('AyaRoundfanHandler',)
 
     def handle(self, evt_type, act):
         if evt_type == 'action_before' and isinstance(act, BaseAttack) and not marked(act, 'freaking_power'):


### PR DESCRIPTION
An temporary end to disputes of event handling order of <after Damage>, Nov. 23rd, 2019

Some reports say 2017-12 uuz production has such MISTAKEN order after dmg.

With our discussed rule (also no diff from old common practice), they are to be changed once and for all only by doing the [anticlockwise from current player Transaction]. But now it seems we can do it one by one.

Start
 >> FerryFeeHandler
 >> MajestyHandler
 >> NenshaPhoneHandler
 >> AyaRoundfanHandler
 >> ResonanceHandler
 >> ReimuClearHandler
 >> MasochistHandler

This time I just mend the time point as follows:

if evt_type == 'action_after' and isinstance(act, Damage)

It is hard to differentiate all of them, so just let it be, if 3 or 4 disputes come, do a 'group = XXTransaction' in emit_event() of cls Game.

Emit event: action_after
 > Handle 50 Disputes of Order
 >> (1, 'AshesHandler')
 >> (2, 'AssistedHealHandler')
 >> (3, 'AutumnWindHandler')
 >> (4, 'CheatingHandler')
 >> (5, 'CraftsmanHandler')
 >> (6, 'DebugHandler')
 >> (7, 'DestructionImpulseHandler')
 >> (8, 'DevotedHandler')
 >> (9, 'DiscarderHandler')
 >> (10, 'DominanceHandler')
 >> (11, 'DyingHandler')
 >> (12, 'EchoHandler')
 >> (13, 'ElingHandler')
 >> (14, 'ExterminateFadeHandler')
 >> (15, 'ExtremeIntelligenceHandler')
 >> (16, 'FerryFeeHandler')
 >> (17, 'FlyingSkandaHandler')
 >> (18, 'GrimoireHandler')
 >> (19, 'ImperishableNightHandler')
 >> (20, 'JiongyanjianHandler')
 >> (21, 'JollyHandler')
 >> (22, 'KOFCharacterSwitchHandler')
 >> (23, 'LittleLegionHandler')
 >> (24, 'LoongPunchHandler')
 >> (25, 'LunaticHandler')
 >> (26, 'MahjongDrugHandler')
 >> (27, 'MajestyHandler')
 >> (28, 'MorphingHandler')
 >> (29, 'NenshaPhoneHandler')
 >> (30, 'RosaHandler')
 >> (31, 'ScarletMistHandler')
 >> (32, 'ScarletPerceptionHandler')
 >> (33, 'ShuffleHandler')
 >> (34, 'SinsackHatHandler')
 >> (35, 'SpiritingAwayHandler')
 >> (36, 'TributeHandler')
 >> (37, 'AyaRoundfanHandler')
 >> (38, 'CiguateraHandler')
 >> (39, 'DilemmaHandler')
 >> (40, 'DisarmHandler')
 >> (41, 'FreakingPowerHandler')
 >> (42, 'LunaDialHandler')
 >> (43, 'SadistHandler')
 >> (44, 'SadistKOFHandler')
 >> (45, 'IbukiGourdHandler')
 >> (46, 'ReimuClearHandler')
 >> (47, 'ReimuExterminateHandler')
 >> (48, 'DecayDamageHandler')
 >> (49, 'MasochistHandler')
 >> (50, 'MelancholyHandler')

Obviously, the handlers followed shall execute after active damage src's EH, at "src == g.current_player != tgt == g.me" time, following the anticlockwise rule:

Mis-postponed active actor skill:
 >> (40, 'DisarmHandler')
 >> (46, 'ReimuClearHandler')
Mistaken too early:
 >> (12, 'EchoHandler')
 >> (27, 'MajestyHandler')
 >> (39, 'DilemmaHandler')

Here we put 2 benchmarks to split active / weapon / passive into 3 parts:
...<all active>
ReimuClear as the last of active; split
Nensha as the first of weapons; split
...<all weapon>
Wine damage adjustment; split
...<all>

Not a problem one: this is evt_type == 'action_after' and isinstance(act, DrawCards)
 >> (8, 'DevotedHandler')

After this change, the order will be:

Emit event: action_after
 > Handle 50 Disputes of Order
 >> (1, 'AshesHandler')
 >> (2, 'AssistedHealHandler')
 >> (3, 'AutumnWindHandler')
 >> (4, 'CheatingHandler')
 >> (5, 'CraftsmanHandler')
 >> (6, 'DebugHandler')
 >> (7, 'DestructionImpulseHandler')
 >> (8, 'DevotedHandler')
 >> (9, 'DiscarderHandler')
 >> (10, 'DominanceHandler')
 >> (11, 'DyingHandler')
 >> (12, 'ElingHandler')
 >> (13, 'ExterminateFadeHandler')
 >> (14, 'ExtremeIntelligenceHandler')
 >> (15, 'FerryFeeHandler')
 >> (16, 'FlyingSkandaHandler')
 >> (17, 'GrimoireHandler')
 >> (18, 'IbukiGourdHandler')
 >> (19, 'ImperishableNightHandler')
 >> (20, 'JiongyanjianHandler')
 >> (21, 'JollyHandler')
 >> (22, 'KOFCharacterSwitchHandler')
 >> (23, 'LittleLegionHandler')
 >> (24, 'LoongPunchHandler')
 >> (25, 'LunaticHandler')
 >> (26, 'MahjongDrugHandler')
 >> (27, 'MorphingHandler')
 >> (28, 'ReimuClearHandler')
 >> (29, 'ReimuExterminateHandler')
 >> (30, 'RosaHandler')
 >> (31, 'ScarletMistHandler')
 >> (32, 'ScarletPerceptionHandler')
 >> (33, 'ShuffleHandler')
 >> (34, 'SinsackHatHandler')
 >> (35, 'SpiritingAwayHandler')
 >> (36, 'TributeHandler')
 >> (37, 'CiguateraHandler')
 >> (38, 'DisarmHandler')
 >> (39, 'FreakingPowerHandler')
 >> (40, 'LunaDialHandler')
 >> (41, 'NenshaPhoneHandler')
 >> (42, 'SadistHandler')
 >> (43, 'SadistKOFHandler')
 >> (44, 'AyaRoundfanHandler')
 >> (45, 'DecayDamageHandler')
 >> (46, 'DilemmaHandler')
 >> (47, 'EchoHandler')
 >> (48, 'MajestyHandler')
 >> (49, 'MasochistHandler')
 >> (50, 'MelancholyHandler')

From now on, no other [after damage] skill ehs go controvertial to:

(1) 插入结算顺序原则：所有结算都是事件在合理的时机插入发生后所进行的处理过程，因此凡是插入发生的事件都优先结算，即后发生的事件先结算。 

(2) 多角色结算顺序原则： 

2.1. 同一张牌、同一个技能或同一个事件对多个目标进行结算时，应从当前回合角色开始按逆时针方向依次进行响应，且若无特别说明，每名角色只能响应一次。 

2.2. 多名角色处于同一个时机且都有此发动时机的技能或（和）此执行时机的技能效果时，应从当前回合角色开始按逆时针方向依次触发或决定是否发动。 

2.3. 角色在使用牌指定多个目标时／后或多名角色成为目标时／后能多次发动按目标人次发动的技能，应依次将从当前回合角色开始按逆时针方向的每个目标人次代入技能的时机里提到的相应角色，并决定是否发动／触发此技能。 

(3) 单角色结算顺序原则： 

3.1. 一名角色在同一个时机能发动角色技能/执行角色技能的效果、发动装备技能/执行装备技能的效果和使用牌／执行牌的操作或效果，应先发动角色技能／执行角色技能的效果，再发动装备技能／执行装备技能的效果，最后使用牌／执行牌的操作或效果。

3.2. 一名角色在同一个时机能发动（多次）（不同的）技能或（和）执行（多次）（不同的）技能的效果时，由其决定操作的顺序（多角色结算原则中的2.3.情况除外）。而发动技能的条件是否满足、目标是否合法的检测，以及消耗的执行，都是在触发或决定是否发动该次技能前进行的。

Ex: 伤害结算中有：伤害结算开始时、造成伤害时、受到伤害时、造成伤害后、受到伤害后、伤害结算结束时六个时机。 

Last but not least, it is promised that it is a directed graph without a ring (passed tests with a same toposort method).
Dump the order list after toposort:

AkiTributeHandler -> AshesHandler -> AssaultKOFHandler -> AssistedHealHandler -> AssistedUseHandler -> AttackCardRangeHandler -> AttackCardVitalityHandler -> AutumnWindHandler -> BaseHopeMaskHandler -> CheatingHandler -> CraftsmanHandler -> DaiyouseiHandler -> DarknessKOFHandler -> DeathSickleHandler -> DebugHandler -> DecayDrawCardHandler -> DestructionImpulseHandler -> DevotedHandler -> DiscarderHandler -> DominanceHandler -> DrunkenDreamHandler -> DyingHandler -> ElingHandler -> EnvyHandler -> EquipmentTransferHandler -> ExinwanHandler -> ExterminateFadeHandler -> ExterminateHandler -> ExtraCardHandler -> ExtraCardSlotHandler -> ExtremeIntelligenceHandler -> ExtremeIntelligenceKOFHandler -> FerryFeeHandler -> FlyingSkandaHandler -> FoisonHandler -> GodDescendantHandler -> GrimoireHandler -> GuidedDeathHandler -> HeartfeltFancyHandler -> HeavyDrinkerHandler -> HeterodoxyHandler -> IbukiGourdHandler -> IceWingHandler -> IdentityRevealHandler -> ImperishableNightHandler -> JiongyanjianHandler -> JollyHandler -> KOFCharacterSwitchHandler -> KanakoFaithKOFHandler -> KeineGuardHandler -> KeystoneHandler -> KnowledgeHandler -> LibraryHandler -> LittleLegionHandler -> LoongPunchHandler -> LuckHandler -> LunaStringLaunchCardHandler -> LunaticHandler -> MahjongDrugHandler -> MindReadHandler -> MiracleMalletHandler -> MorphingHandler -> NakedFoxHandler -> NitoryuuWearEquipmentHandler -> PerfectCherryBlossomHandler -> ProphetHandler -> PsychopathHandler -> QiliaoDropHandler -> QiliaoRecoverHandler -> RebornHandler -> ReimuClearHandler -> ReimuExterminateHandler -> RepentanceStickHandler -> ReturningHandler -> ReversalHandler -> ReversedScalesHandler -> RiverBehindHandler -> RiversideHandler -> RosaHandler -> RoukankenEffectHandler -> SanaeFaithKOFHandler -> ScarletMistHandler -> ScarletPerceptionHandler -> SentryHandler -> ShikigamiHandler -> ShipwreckHandler -> ShuffleHandler -> SinsackHatHandler -> SolidShieldHandler -> SoulDrainHandler -> SpiritingAwayHandler -> SummonHandler -> SummonKOFHandler -> SuwakoHatHandler -> TianyiHandler -> TreasureHuntHandler -> TrialHandler -> TributeHandler -> UFODistanceHandler -> UltimateSpeedHandler -> UmbrellaHandler -> VampireKissHandler -> VengeOfTsukumogamiHandler -> VirtueHandler -> VitalityHandler -> WeaponReforgeHandler -> WindWalkHandler -> XianshizhanHandler -> YinYangOrbHandler -> YoumuHandler -> YoumuPhantomHandler -> CiguateraHandler -> DeathHandler -> DisarmHandler -> ElementalReactorHandler -> FreakingPowerHandler -> HakuroukenHandler -> LaevateinHandler -> LunaDialHandler -> NenshaPhoneHandler -> OpticalCloakHandler -> PerfectFreezeHandler -> ResonanceHandler -> SadistHandler -> SadistKOFHandler -> SupportKOFHandler -> TelegnosisHandler -> AyaRoundfanHandler -> CriticalStrikeHandler -> DecayDamageHandler -> DilemmaHandler -> EchoHandler -> FourOfAKindHandler -> HeritageHandler -> MajestyHandler -> MasochistHandler -> MelancholyHandler -> MomijiShieldHandler -> HouraiJewelHandler -> MaidenCostumeHandler -> RejectHandler -> SpearTheGungnirHandler -> WineHandler

End.