### PR TITLE
Fix Kyouko+Kaguya bug: add Kaguya's test sequence to protect

### DIFF
--- a/src/thb/characters/kaguya.py
+++ b/src/thb/characters/kaguya.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from game.autoenv import EventHandler, Game, user_input
 from thb.actions import Damage, DrawCards, LaunchCard, LifeLost, UserAction, migrate_cards
 from thb.actions import skill_check, skill_wrap, user_choose_cards
-from thb.cards import Card, Heal, SealingArrayCard, Skill, TreatAs, VirtualCard, t_None
+from thb.cards import Card, Heal, HiddenCard, SealingArrayCard, Skill, TreatAs, VirtualCard, t_None
 from thb.characters.baseclasses import Character, register_character_to
 from thb.inputlets import ChooseOptionInputlet
 
@@ -106,6 +106,8 @@ class ImperishableNightHandler(EventHandler):
 
         card = act.card
         if not card: return act
+        # Inserted settlements, like kyouko, report HiddenCard has no 'category', CRASH; prevention:
+        if card.is_card(HiddenCard): return act
         if 'basic' not in card.category: return act
         if card.color != Card.RED: return act
 


### PR DESCRIPTION
投诉称，响子和团扇出现时，有时偶发问题。
查client_log发现是辉夜。属于第三方，技能管得太宽。
当时查看不少对照组，凡是辉夜不在，就没有团扇响子问题。
详查得：
是一个鬼故事,当时调查了很久，团扇竟然能让不相干的手牌变成隐藏的洗牌，以至于影响到了辉夜模块和这里的接口（竟然改掉了card的根本属性）

具体出现：

0. 攻击者使用红色弹幕，击伤响子；伤害是使用牌的插入结算。

1. 响子回响了牌。收到自己手牌。

2. 团扇发动，虽然只是针对装备，但本身触发了ShuffleHandler。

3. ShuffleHandler令响子的手牌里，那张牌变成了HiddenCard，一切原牌属性消除。

4. 伤害结算完毕，结算“使用后”（after ActionStageLaunchCard），辉夜对于那张牌计数，校验序列走到if card.category，报错，该牌根本没有这个属性。


具体展开：

equipment.py
```python
# in RoundRan
equip = user_input([src], ChoosePeerCardInputlet(self, tgt, ['equips']))
```

actions.py：
```python
# see the shuffle which makes the card concealed
@register_eh
class ShuffleHandler(EventHandler):
    interested = ('action_after', 'action_before', 'action_stage_action', 'card_migration', 'user_input_start')
    def handle(self, evt_type, arg):
        if evt_type == 'action_stage_action':
            self.do_shuffle()
        elif evt_type in ('action_before', 'action_after') and isinstance(arg, ActionStage):
            self.do_shuffle()
        elif evt_type == 'user_input_start':
            trans, ilet = arg
            if isinstance(ilet, ChoosePeerCardInputlet):
                self.do_shuffle([ilet.target])
```
after the card in hand gets hidden, kaguya will see it as hidden card.

以后辉夜还是会这样对于可能已经被修改了属性的牌走校验序列……


辉夜就是会管得很宽，其接口的防御只好加一层。
make kaguya's bool test less vulnerable
HiddenCard


按照之前的提交（顺序那个），渡钱>团扇>回响，已经处理了这个问题。鉴于辉夜总是管得很宽，万一下次又谁将牌藏起来了，这种事情还是要防守的啦。