### PR TITLE
:bug: Make Rumia CheatingHandler Consistent with description

### DIFF
--- a/src/thb/characters/medicine.py
+++ b/src/thb/characters/medicine.py
@@ -37,7 +37,7 @@ class CiguateraAction(UserAction):
 
 
 class CiguateraHandler(EventHandler):
-    interested = ('action_after', 'action_before')
+    interested = ('action_before',)
     card_usage = 'drop'
 
     def handle(self, evt_type, act):

--- a/src/thb/characters/rumia.py
+++ b/src/thb/characters/rumia.py
@@ -4,7 +4,7 @@
 # -- third party --
 # -- own --
 from game.autoenv import ActionShootdown, EventHandler, Game
-from thb.actions import Damage, DrawCards, LaunchCard, PlayerTurn, UserAction
+from thb.actions import Damage, DrawCards, FinalizeStage, LaunchCard, UserAction
 from thb.actions import user_choose_cards
 from thb.cards import Attack, AttackCard, BaseDuel, PhysicalCard, RejectCard, Skill, t_None, t_OtherN
 from thb.characters.baseclasses import Character, register_character_to
@@ -138,11 +138,11 @@ class CheatingDrawCards(DrawCards):
 
 
 class CheatingHandler(EventHandler):
-    interested = ('action_after',)
+    interested = ('action_apply',)
     execute_before = ('CiguateraHandler', )
 
     def handle(self, evt_type, act):
-        if evt_type == 'action_after' and isinstance(act, PlayerTurn):
+        if evt_type == 'action_apply' and isinstance(act, FinalizeStage):
             tgt = act.target
             if tgt.has_skill(Cheating) and not tgt.dead:
                 g = Game.getgame()


### PR DESCRIPTION
According to card description, Rumia's CheatingHandler shall get triggered the same time as ReimuExterminateHandler, and when the two coincide, it has been defined in reimu.py that Rumia's time has higher priority, while actually Rumia's time is later, due to the mistaken code writing "after PlayerTurn" (shall be adjusted to "apply FinalizeStage").