### PR TITLE
Make Chen UI consistent with implementation and prevent showing UI error

### DIFF
--- a/src/thb/ui/ui_meta/characters/chen.py
+++ b/src/thb/ui/ui_meta/characters/chen.py
@@ -40,9 +40,11 @@ class FlyingSkanda:
         while True:
             if c.is_card(cards.AttackCard): break
 
-            rst = c.is_card(cards.RejectCard)
-            rst = rst or c.is_card(cards.DollControlCard)
-            rst = (not rst) and issubclass(c.associated_action, cards.InstantSpellCardAction)
+            rst = True
+            rst = rst and not c.is_card(cards.RejectCard)
+            rst = rst and not c.is_card(cards.DollControlCard)
+            rst = rst and c.associated_action
+            rst = rst and issubclass(c.associated_action, cards.InstantSpellCardAction)
             if rst: break
 
             return (False, u'请选择一张【弹幕】或者除【人形操控】与【好人卡】之外的非延时符卡！')


### PR DESCRIPTION
A bug in UI test sequence.
In ui_meta.chen.py, class FlyingSkanda, while testing if chosen rawcard satisfying the conditions, there is a mistake which exposes <error>.
If and Only if choosing a GrazeCard, it shows "ui.ui_meta 错误", which is due to grazecard being the only basic card with None as associated_action.
Old code:
while True:
    if c.is_card(cards.AttackCard): break
    rst = c.is_card(cards.RejectCard)
    rst = rst or c.is_card(cards.DollControlCard)
    rst = (not rst) and issubclass(c.associated_action, cards.InstantSpellCardAction)
    if rst: break
        return (False, u'请选择一张【弹幕】或者除【人形操控】与【好人卡】之外的非延时符卡！')
Here the code gets:
#=======GAME STARTED: 601278=======
#<THBattle2v2 at 0x1996c710>
#>> Player: Tewi:MORIYA [FFEBCD]枫
#>> Player: Nazrin:HAKUREI 樱花味厨娘
#>> Player: Shikieiki:HAKUREI 梦境
#>> Player: Chen:MORIYA CoffeeYin
#Starting new HTTPS connection (1): api.leancloud.cn
#Starting new HTTPS connection (1): api.leancloud.cn
#card.ui_meta.is_action_valid error

Traceback (most recent call last):
File "C:\Users\17000\Pictures\THBattle\thbattle\src\thb\ui\ui_meta\inputlets.py", line 157, in actv_handle_target_selection

rst, reason = card.ui_meta.is_action_valid(g, [card], target_list)

File "C:\Users\17000\Pictures\THBattle\thbattle\src\thb\ui\ui_meta\characters\chen.py", line 45, in is_action_valid

 rst = (not rst) and issubclass(c.associated_action, cards.InstantSpellCardAction)

TypeError: issubclass() arg 1 must be a class

In Graze's a_a, None instead.

As a result, add one line to let Graze go False first.
