### PR TITLE
:wrench: Fix LaunchCard return rst for Invalid Actions

### DIFF
--- a/src/game/base.py
+++ b/src/game/base.py
@@ -457,6 +457,7 @@ class Game(GameObject):
         elif not action.can_fire():
             log.debug('action invalid, not firing: %s' % action.__class__.__name__)
             action.invalid = True
+            rst = False
         else:
             log.debug('applying action %s, current hybrid_stack: %r' % (action.__class__.__name__, self.hybrid_stack))
             action = self.emit_event('action_apply', action)


### PR DESCRIPTION
When an action can_fire() -> True before action, and can_fire() -> False after being interfered by anything like RejectCard, it shows that the LC has no rst to return.

tarting new HTTPS connection (1): api.leancloud.cn
Starting new HTTPS connection (1): api.leancloud.cn
Starting new HTTPS connection (1): api.leancloud.cn
Starting new HTTPS connection (1): api.leancloud.cn
Starting new HTTPS connection (1): api.leancloud.cn
Starting new HTTPS connection (1): api.leancloud.cn
<THBattleIdentity at 0x1ee43530> failed with UnboundLocalError
Traceback (most recent call last):
  File "C:\thbattle\Python27\lib\site-packages\gevent\greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "C:\thbattle\src\client\core\game_client.py", line 229, in _run
    g.process_action(g.bootstrap(g.game_params, g.game_items))
  File "C:\thbattle\src\game\base.py", line 467, in process_action
    rst = action.apply_action()
  File "C:\thbattle\src\thb\thbidentity.py", line 505, in apply_action
    g.process_action(PlayerTurn(p))
  File "C:\thbattle\src\game\base.py", line 467, in process_action
    rst = action.apply_action()
  File "C:\thbattle\src\thb\actions.py", line 1097, in apply_action
    g.process_action(cs)
  File "C:\thbattle\src\game\base.py", line 467, in process_action
    rst = action.apply_action()
  File "C:\thbattle\src\thb\actions.py", line 809, in apply_action
    if not g.process_action(lc):
  File "C:\thbattle\src\game\base.py", line 467, in process_action
    rst = action.apply_action()
  File "C:\thbattle\src\thb\actions.py", line 684, in apply_action
    g.process_action(a)
  File "C:\thbattle\src\game\base.py", line 496, in process_action
    return rst
UnboundLocalError: local variable 'rst' referenced before assignment
=======GAME ENDED=======