### PR TITLE
:bug: Make KOF Daiyousei HP = 0 after Support YoumuPhantom

### DIFF
--- a/src/thb/cards/equipment.py
+++ b/src/thb/cards/equipment.py
@@ -986,6 +986,9 @@ class YoumuPhantomHandler(EventHandler):
 
         g = Game.getgame()
 
+        # Only for daiyousei in KOF, no better fix:
+        if to.type == 'support': return arg
+
         if _from is not None and _from.type == 'equips' and not is_bh:
             for c in cards:
                 if c.is_card(YoumuPhantomCard):


### PR DESCRIPTION
Complaints argue that when KOF's Daiyousei is fallen, giving YoumuPhantom to the next chosen character, her HP will be 1 then get fallen, which shows both strings and se in UI. Fix it.