### PR TITLE
:bug: Make Mokou Reborn play well with Exinwan

### DIFF
--- a/src/thb/characters/mokou.py
+++ b/src/thb/characters/mokou.py
@@ -78,7 +78,8 @@ class RebornHandler(EventHandler):
             if cards:
                 g = Game.getgame()
                 g.process_action(DropCards(tgt, tgt, cards))
-                g.process_action(RebornAction(tgt))
+                if not tgt.dead: # Ensure no ui action_effect_after (str | se) after drop Exinwan causing fall
+                    g.process_action(RebornAction(tgt))
 
         return act
 


### PR DESCRIPTION
There are records that Mokou is really fallen then use Exinwan to revive (not truly), but then get poisoned by Medicine.
It's a problem in UI with str|se.