### PR TITLE
:bug: Ensure Medicine cannot Ciguatera on FatetellStage dead characters

### DIFF
--- a/src/thb/characters/medicine.py
+++ b/src/thb/characters/medicine.py
@@ -42,6 +42,7 @@ class CiguateraHandler(EventHandler):
 
     def handle(self, evt_type, act):
         if evt_type == 'action_before' and isinstance(act, FatetellStage):
+            if act.target.dead: return act
             g = Game.getgame()
             for p in g.players:
                 if p.dead:


### PR DESCRIPTION
Take the former Mokou dead in "before fatetell" using exinwan as an example: medicine shall judge if the character she tried to poison is still alive when processed before the "before fatetell".