### PR TITLE
:speech_balloon: Make Seija Reversal description consistent with impl…

### DIFF
--- a/src/thb/ui/ui_meta/characters/seija.py
+++ b/src/thb/ui/ui_meta/characters/seija.py
@@ -104,7 +104,7 @@ class InciteAction:
 class Reversal:
     # Skill
     name = u'逆转'
-    description = u'当你受到一名其他角色使用的|G弹幕|r效果时，你可以摸一张牌，然后若你的手牌数大于其手牌数，你将此|G弹幕|r视为|G弹幕战|r'
+    description = u'当你受到一名其他角色使用的|G弹幕|r效果时，你可以摸一张牌，然后若你的手牌数大于其手牌数，取消该|G弹幕|r效果，并视为该角色再对你使用一张|G弹幕战|r'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid


### PR DESCRIPTION
Consider the 2 following instances:
Seija reverses Patchouli, triggering her Library skill;
Seija reverses aya's 1st card ASLC, then triggers aya's skill ultimate speed.

Code:

```
g.process_action(DrawCards(tgt, 1))
if nhand(tgt) > nhand(src):
                g.process_action(LaunchCard(src, [tgt], ReversalDuel(src)))
                act.cancelled = True 
```
As is known that seija.py gives another launch in implementation, change description to fit card code.

For yuuka reversed-scales, it needs not change, as it is:
```
def apply_action(self):
      self.action.__class__ = Duel 
```