### PR TITLE
:bug: Make Kanako apply FaithEffect only when both source and target …

### DIFF
--- a/src/thb/characters/kanako.py
+++ b/src/thb/characters/kanako.py
@@ -31,8 +31,8 @@ class KanakoFaithCounteract(UserAction):
     def apply_action(self):
         src, tgt = self.source, self.target
         g = Game.getgame()
-        g.process_action(KanakoFaithCounteractPart1(src, tgt))
-        g.process_action(KanakoFaithCounteractPart2(src, tgt))
+        src.dead or tgt.dead or g.process_action(KanakoFaithCounteractPart1(src, tgt))
+        src.dead or tgt.dead or g.process_action(KanakoFaithCounteractPart2(src, tgt))
         return True
 
 


### PR DESCRIPTION
So many complaints say if kanako herself failed in Duel or get fallen by Shinmyoumaru, the effect of shooting Faith is still on (for other characters left), as is the target she aim at.
It is related to the relative strength and game's logic, which is obliged to be taken seriously.