### PR TITLE
:bug: Make AyaRoundfan execute after Dying AskingForHeal

### DIFF
--- a/src/thb/cards/equipment.py
+++ b/src/thb/cards/equipment.py
@@ -733,6 +733,7 @@ class AyaRoundfanSkill(WeaponSkill):
 @register_eh
 class AyaRoundfanHandler(EventHandler):
     interested = ('action_after',)
+    execute_after = ('DyingHandler', )
     card_usage = 'drop'
 
     def handle(self, evt_type, act):


### PR DESCRIPTION
It is an accidental problem because the handler toposorting graph has already made ayaroundfan goes after Reimu, Momiji and so on, however, when it comes to a small game without anything else but only the AyaRoundfan and Dying, A goes prior to D, a local diorder is invoked.

Fix it.