### PR TITLE
:bug: Make Youmu Vitality no exceeding two in a single turn

### DIFF
--- a/src/thb/characters/youmu.py
+++ b/src/thb/characters/youmu.py
@@ -108,8 +108,9 @@ class YoumuHandler(EventHandler):
 
                 n = self.weapons(p)
                 dn = len(cards)
+                if not any(getattr(c, 'equipment_category', None) == 'weapon' for c in cards): continue
 
-                if cl is _from and (dn + n) >= 2 and n <= 1 and any(getattr(c, 'equipment_category', None) == 'weapon' for c in cards):
+                if cl is _from and (dn + n) >= 2 and n <= 1:
                     adjust = -1
                 elif cl is to and (n - dn) <= 1 and n >= 2:
                     adjust = 1


### PR DESCRIPTION
Complaints on Dec 4, 2019:
Some players argue that they witness a 3 vitality youmu...
Same problem as the zero vitality one:
Imagine youmu is with 2 weapons already, and then put on a UFO... Vitality Double plus.
Fixed just like the 0 vitality case.