### PR TITLE
:bug: Make SP Flandre DestructionImpulse implementation play well wit…

### DIFF
--- a/src/thb/characters/sp_flandre.py
+++ b/src/thb/characters/sp_flandre.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 # -- third party --
 # -- own --
 from game.autoenv import EventHandler, Game, user_input
-from thb.actions import Damage, GenericAction, LaunchCard, LifeLost, MaxLifeChange, PlayerTurn
+from thb.actions import Damage, FinalizeStage, GenericAction, LaunchCard, LifeLost, MaxLifeChange
 from thb.actions import ttags, user_choose_players
 from thb.cards import Skill, t_None
 from thb.characters.baseclasses import Character, register_character_to
@@ -26,8 +26,8 @@ class DestructionImpulseAction(GenericAction):
         tgt = self.target
         g = Game.getgame()
 
-        g.process_action(LifeLost(src, src))
         g.process_action(Damage(src, tgt))
+        g.process_action(LifeLost(src, src))
 
         return True
 
@@ -45,7 +45,7 @@ class DestructionImpulseHandler(EventHandler):
             g = Game.getgame()
             ttags(src)['destruction_tag'] = True
 
-        elif evt_type == 'action_after' and isinstance(act, PlayerTurn):
+        elif evt_type == 'action_after' and isinstance(act, FinalizeStage):
             tgt = act.target
             if not tgt.has_skill(DestructionImpulse): return act
 

--- a/src/thb/ui/ui_meta/characters/sp_flandre.py
+++ b/src/thb/ui/ui_meta/characters/sp_flandre.py
@@ -25,7 +25,7 @@ class SpFlandre:
 class DestructionImpulse:
     # Skill
     name = u'破坏冲动'
-    description = u'|B锁定技|r，结束阶段开始时，若你本回合没有造成过伤害，你失去1点体力并对距离最近的一名其他角色造成1点伤害。'
+    description = u'|B锁定技|r，结束阶段结束后，若你本回合没有造成过伤害，你对距离最近的一名其他角色造成1点伤害，并失去1点体力。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid


### PR DESCRIPTION
{1} Solve all disputes between sp and KOF debut handler, Yuyuko and KOF Yugi Assault;

{2} Let damage goes prior to SP Flandre's fall - dead character cannot fire anything (rationalize skill), also the Yuyuko draw card problem;

{3} Make right of time of SP Flan Destruction Impulse.