### PR TITLE
:speech_balloon: Make Shizuha Decay Effect description consistent wit…

### DIFF
--- a/src/thb/ui/ui_meta/characters/shizuha.py
+++ b/src/thb/ui/ui_meta/characters/shizuha.py
@@ -36,7 +36,7 @@ class AutumnWindAction:
 class Decay:
     # Skill
     name = u'凋零'
-    description = u'|B锁定技|r。你的回合内，每当其他角色失去最后的手牌时，你摸一张牌；你的回合外，每当你受到一次伤害后，当前回合角色于本回合弃牌阶段需额外弃置一张手牌（该效果不可叠加）。'
+    description = u'|B锁定技|r。你的回合内，每当其他角色失去最后的手牌时，你摸一张牌；你的回合外，当你受到伤害后，当前回合角色获得|G凋零|r标记，有该标记的角色于下一个弃牌阶段须额外弃置一张手牌，而后移除该标记（该标记不可叠加）'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid


### PR DESCRIPTION
Tradeoff以后决定改描述……
{1} 减少同一个EH对于多个事件监听导致的可能的差池和顺序问题（不敢以新潜在bug来fix）；
{2} 可以形成玩家对角色评估印象的一致预期且保持角色的相对强度；
{3} 可以开启标记系统的设计思路，原来就叫tag；
{4} 线下问题，事实上线下就算是同一个回合内记忆加标记都需要受害者去提醒，而且人形操控、霍青娥等情况时往往忘记谁加标记。标记作为记忆载体，利于理清关系且寻找小方块的实体也符合广义Bang!类游戏的风格……