### PR TITLE
:speech_balloon: Fix Ran ExtremeIntelligence lines

### DIFF
--- a/src/thb/ui/ui_meta/characters/ran.py
+++ b/src/thb/ui/ui_meta/characters/ran.py
@@ -25,7 +25,7 @@ class Prophet:
 class ExtremeIntelligence:
     # Skill
     name = u'极智'
-    description = u'每轮限一次，你的回合外，当非延时符卡对一名角色生效后，你可以弃置一张牌，令该符卡效果对那名角色重新进行一次结算，此时使用者视为你。'
+    description = u'每轮限一次，你的回合外，当非延时符卡效果对一名角色生效后，你可以弃置一张牌，令该符卡效果对那名角色重新进行一次结算，此时使用者视为你。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid


### PR DESCRIPTION
Disputes occur when HouraiJewel and Ran's EI coincide. Since the HouraiJewel is SpellCardAction but has no SpellCard, and Ran's Handler listens this Action:
``` 
class ExtremeIntelligenceHandler(EventHandler):
    interested = ('action_after', 'game_begin')

    def handle(self, evt_type, act):
        if evt_type == 'action_after' and isinstance(act, InstantSpellCardAction):
            if isinstance(act, Reject): return act
            g = Game.getgame()
            target = g.current_player
```

Also, players are used to using Ran EI to repeat the Jewel's SpellCardAction.

Change the lines (add one word) accordingly.