### PR TITLE
:bug: Fix ScarletRhapsodySkill checking conditions

### DIFF
--- a/src/thb/cards/equipment.py
+++ b/src/thb/cards/equipment.py
@@ -387,7 +387,7 @@ class ScarletRhapsodySkill(WeaponSkill):
             check(card.is_card(PhysicalCard))
 
             check(card.resides_in in (tgt.cards, tgt.showncards))
-            check(card in tgt.cards) or card in set(tgt.showncards)
+            check(card in set(tgt.cards) or card in set(tgt.showncards))
 
             check(set(tgt.cards) | set(tgt.showncards) == set([card]))
 


### PR DESCRIPTION
Old ver:
```
check(card in tgt.cards) or card in set(tgt.showncards)
```
If check failed then UI report (prompt) words...
Change into:
```
check(card in set(tgt.cards) or card in set(tgt.showncards))
```
