### PR TITLE
:bug: Overall Fix of detachment and bottomHalf dispute between parsee…

### DIFF
--- a/src/thb/characters/alice.py
+++ b/src/thb/characters/alice.py
@@ -228,7 +228,7 @@ class DollBlastMigrationHandler(DollBlastHandlerCommon, EventHandler):
         equips = p.equips
 
         for cl, _from, to, is_bh, _ in trans.get_movements():
-            if _from is not equips:
+            if _from is not equips or is_bh:
                 continue
 
             if to is None or not to.owner:

--- a/src/thb/characters/parsee.py
+++ b/src/thb/characters/parsee.py
@@ -29,7 +29,8 @@ class Envy(TreatAs, Skill):
 class EnvyRecycleAction(object):
     def apply_action(self):
         detach_cards(self.cards)
-        migrate_cards(self.cards, self.source.cards, unwrap=True)
+        assert self.cards[0].detached
+        migrate_cards(self.cards, self.source.cards, is_bh=True, unwrap=True)
         return True
 
 

--- a/src/thb/characters/rinnosuke.py
+++ b/src/thb/characters/rinnosuke.py
@@ -60,6 +60,7 @@ class PsychopathHandler(EventHandler):
     def handle(self, evt_type, args):
         if evt_type == 'card_migration':
             act, cards, _from, to, is_bh = args
+            cards = [c for c in cards if not c.detached]
             if _from is not None and _from.type == 'equips' and not is_bh:
                 src = _from.owner
                 if src.has_skill(Psychopath) and not src.dead:


### PR DESCRIPTION
After overall and detailed investigation, the detachment mechanism which means:

Cardlist forgets the card, but card.attr still remains the Cardlist.

detach的实现是，把它residesin的这个卡堆里remove这张牌，但这张牌却从未失去residesin的卡堆。。也即，它detached状态下，residesin是not None，且它不在里面。此时 爱莉丝 与 乡长两次计算，就是来自这里。

Keeping this, it is tested under local tests that if the "bottom half" (detached is the src list, and move to the other place) shall never trigger alice or rinnosuke's skill.

Changes are made in 3 files...