### PR TITLE
:bug: Adjust ReimuExterminate Order after active and weapon skills

### DIFF
--- a/src/thb/characters/reimu.py
+++ b/src/thb/characters/reimu.py
@@ -161,7 +161,15 @@ class ReimuExterminateAction(AskForCard):
 
 class ReimuExterminateHandler(EventHandler):
     interested = ('action_apply', 'action_after')
-    execute_after = ('DyingHandler', 'CheatingHandler', 'IbukiGourdHandler')
+    execute_after = ('DyingHandler',
+                     'CheatingHandler',
+                     'IbukiGourdHandler',
+                     'DisarmHandler',
+                     'FreakingPowerHandler',
+                     'LunaticHandler',
+                     'AyaRoundfanHandler',
+                     'NenshaPhoneHandler',
+                     )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_apply' and isinstance(act, Damage):


### PR DESCRIPTION
 > Handle 6 Disputes of Order
 >> (1, 'LunaticHandler')
 >> (2, 'DisarmHandler')
 >> (3, 'FreakingPowerHandler')
 >> (4, 'NenshaPhoneHandler')
 >> (5, 'AyaRoundfanHandler')
 >> (6, 'ReimuExterminateHandler')


All 5 comparisons have passed local test.