### PR TITLE
:bug: Final fix of Rinnosuke 0 card or 4 cards using is_bh instead of…

### DIFF
--- a/src/thb/characters/rinnosuke.py
+++ b/src/thb/characters/rinnosuke.py
@@ -60,7 +60,7 @@ class PsychopathHandler(EventHandler):
     def handle(self, evt_type, args):
         if evt_type == 'card_migration':
             act, cards, _from, to, is_bh = args
-            cards = [c for c in cards if not c.detached]
+
             if _from is not None and _from.type == 'equips' and not is_bh:
                 src = _from.owner
                 if src.has_skill(Psychopath) and not src.dead:


### PR DESCRIPTION
It passed local test.
From now on, not once will rinnosuke do 0 or 4 cards again... it also includes when parsee meets rinnosuke launching the EnvyRecycle.
The `is_bh` is definetely working well with parsee.