### PR TITLE
:bug: Fix conflict between Resonance and Reversal

### DIFF
--- a/src/thb/characters/kyouko.py
+++ b/src/thb/characters/kyouko.py
@@ -145,7 +145,7 @@ class ResonanceHandler(EventHandler):
             src = act.source
             tgt = act.target
 
-            if src.dead or tgt.dead:
+            if act.cancelled or src.dead or tgt.dead:
                 return act
 
             if not src.has_skill(Resonance):


### PR DESCRIPTION
Once Seija's Reversal cancelled the attack and transtyped it into a Duel, Kyouko shall no longer be able to launch a resonanced attack upon Seija.

Passed local test 2v2, no crash.