### PR TITLE
:bug: Fix cancelled user choice eviting card selection of Yugi, Shiki…

### DIFF
--- a/src/thb/characters/kyouko.py
+++ b/src/thb/characters/kyouko.py
@@ -145,7 +145,7 @@ class ResonanceHandler(EventHandler):
             src = act.source
             tgt = act.target
 
-            if src.dead or tgt.dead:
+            if act.cancelled or src.dead or tgt.dead:
                 return act
 
             if not src.has_skill(Resonance):

--- a/src/thb/characters/minoriko.py
+++ b/src/thb/characters/minoriko.py
@@ -104,7 +104,8 @@ class AkiTributeHandler(EventHandler):
 
             candidates = [p for p in g.players if not p.dead]
             pl = user_choose_players(self, src, candidates)
-            if not pl: return act
+            if not pl:
+                pl = [src]
 
             tgt, = pl
             g.process_action(AkiTributeCollectCard(src, tgt, cards))

--- a/src/thb/characters/shikieiki.py
+++ b/src/thb/characters/shikieiki.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 # -- own --
 from game.autoenv import EventHandler, Game, user_input
 from thb.actions import Damage, FatetellMalleateHandler, MigrateCardsTransaction, UseCard
-from thb.actions import UserAction, detach_cards, migrate_cards, user_choose_cards
+from thb.actions import UserAction, detach_cards, migrate_cards, random_choose_card, user_choose_cards
 from thb.cards import Skill, t_None
 from thb.characters.baseclasses import Character, register_character_to
 from thb.inputlets import ChooseOptionInputlet, ChoosePeerCardInputlet
@@ -77,6 +77,7 @@ class MajestyAction(UserAction):
     def apply_action(self):
         src, tgt = self.source, self.target
         c = user_input([src], ChoosePeerCardInputlet(self, tgt, ('cards', 'showncards', 'equips')))
+        c = c or random_choose_card([tgt.cards, tgt.showncards, tgt.equips])
         if not c: return False
         src.reveal(c)
         migrate_cards([c], src.cards)

--- a/src/thb/characters/yugi.py
+++ b/src/thb/characters/yugi.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 # -- third party --
 # -- own --
 from game.autoenv import EventHandler, Game, user_input
-from thb.actions import Damage, DropCards, FatetellAction, LaunchCard, mark, marked
+from thb.actions import Damage, DropCards, FatetellAction, LaunchCard, mark, marked, random_choose_card
 from thb.cards import AttackCard, BaseAttack, Card, InevitableAttack, RedUFOSkill, Skill
 from thb.cards import TreatAs, VirtualCard, t_None
 from thb.characters.baseclasses import Character, register_character_to
@@ -102,8 +102,12 @@ class FreakingPowerHandler(EventHandler):
             src, tgt = pact.source, act.target
             if tgt.dead: return act
 
+            if not (tgt.cards or tgt.showncards or tgt.equips):
+                return act
+
             catnames = ('cards', 'showncards', 'equips')
             card = user_input([src], ChoosePeerCardInputlet(self, tgt, catnames))
+            card = card or random_choose_card([tgt.cards, tgt.showncards, tgt.equips])
             if card:
                 g.players.exclude(tgt).reveal(card)
                 g.process_action(DropCards(src, tgt, [card]))


### PR DESCRIPTION
User report (http://www.thbattle.net/thread-81566-1-1.html) finds conflicts in Yugi, Shikieiki and Minoriko between implementation and description on thb.io, which has been solved:
Once chosen to exert the skill, all actions are locked. If the player cancels, random choice will decide the selection's fate. There is no way to run away from it.
Example: when someone intentionally put only YoumuPhantom for Yugi or Shiki to take, or the victim intentionally put the only Exinwan at hand for Yugi to drop... in the previous cases, Yugi (fatetelling black) is not to escape from the fate of dropping an only Exinwan, in spite of choosing nothing in the inputlet, fully waiting after 25 wasted seconds.

No crash passing local test. (3 of them)