### PR TITLE
:wrench: Make SpSatori unable to collect pooled characters avoiding p…

### DIFF
--- a/src/thb/common.py
+++ b/src/thb/common.py
@@ -109,11 +109,6 @@ def build_choices(g, items, candidates, players, num, akaris, shared):
     all_characters = Character.character_classes
     testing = list(all_characters[i] for i in settings.TESTING_CHARACTERS)
 
-    # HACK!
-    import sys
-    if 'satori' in sys._getframe(1).f_code.co_filename:
-        testing = []
-
     # ==============
 
     candidates, _ = partition(lambda c: c not in testing, candidates)

--- a/src/thb/thbfaith.py
+++ b/src/thb/thbfaith.py
@@ -182,6 +182,9 @@ class THBattleFaithBootstrap(GenericAction):
         first_index = pl.index(first)
         order = BatchList(range(len(pl))).rotate_to(first_index)
 
+        # Inaccessible Bottom Pocket:
+        g.pool = force_hakurei.pool + force_moriya.pool
+
         for p in pl:
             g.process_action(RevealIdentity(p, pl))
 

--- a/src/thb/thbkof.py
+++ b/src/thb/thbkof.py
@@ -179,6 +179,11 @@ class THBattleKOFBootstrap(GenericAction):
 
         order = [1, 0] if A is g.players[0] else [0, 1]
 
+        # Inaccessible Bottom Pocket:
+        g.pool = []
+        for p in [A, B]:
+            g.pool += list(p.choices)
+
         for p in [A, B]:
             g.process_action(RevealIdentity(p, g.players))
 


### PR DESCRIPTION
Potential bugs have been made to occur if the players first choose A as SpSatori to learn ScarletPerception, and then B has a Tenshi or Sanae in pool, not on stage yet.
It is asserted in SanaeKOF that if her opponent gets card in self action stage, Sanae must get one card from the Deck, if both characters can collect cards from the deck, there will be an endless loop; also, Tenshi's ScarletPerception asserts that the number of players owning this skill has to be no larger than 1, which directly leads to a crash.
To cope with this potential bug, in KOF and Faith modes, SpSatori is no longer able to recollect any skill from a character in pool (not yet but will soon make a debut). Also, the pool attribute is recorded by the game object itself as `g.pool` of these 2 modes which switches characters during one single game's process.
Last but not least, local tests have been done and no bugs detected yet.