### PR TITLE
:bug: Solve time delay caused by PerfectCherryBlossom and Summon

### DIFF
--- a/src/thb/characters/seiga.py
+++ b/src/thb/characters/seiga.py
@@ -148,10 +148,11 @@ class SummonAction(UserAction):
 
 
 class SummonHandler(EventHandler):
-    interested = ('action_before', )
+    interested = ('action_apply', )
+    execute_after = ('DeathHandler', )
 
     def handle(self, evt_type, act):
-        if evt_type == 'action_before' and isinstance(act, PlayerDeath):
+        if evt_type == 'action_apply' and isinstance(act, PlayerDeath):
             g = Game.getgame()
             p = getattr(g, 'current_player', None)
 

--- a/src/thb/characters/yuyuko.py
+++ b/src/thb/characters/yuyuko.py
@@ -146,6 +146,7 @@ class SoulDrainHandler(EventHandler):
 
 class PerfectCherryBlossomHandler(EventHandler):
     interested = ('action_apply', 'action_before')
+    execute_after = ('DeathHandler', )
 
     def handle(self, evt_type, act):
         if evt_type == 'action_apply' and isinstance(act, PlayerDeath):


### PR DESCRIPTION
It is reported that Seiga and Yuyuko will waste some time if boss is shot down in games.
Also, the real time that Seiga executes her event shall be readjusted according to the description.

Local test passed; no bugs yet.

Also, no rings detected in the TOPOSORT graph:

Type in EventHandlers' Names: (if end, type enter)

 Handle 4 Disputes of Order
> (1, 'SummonKOFHandler')
> (2, 'DeathHandler')
> (3, 'PerfectCherryBlossomHandler')
> (4, 'SummonHandler')

(With time goes by, the system shall no longer rely on toposort... this is just a example... when seiga and yuyuko matter on other one's fall and their eventListeners make it coincide)

AkiTributeHandler -> AshesHandler -> AssaultKOFHandler -> AssistedHealHandler -> AssistedUseHandler -> AttackCardRangeHandler -> AttackCardVitalityHandler -> AutumnWindHandler -> BaseHopeMaskHandler -> CheatingHandler -> CraftsmanHandler -> DaiyouseiHandler -> DarknessKOFHandler -> DeathSickleHandler -> DebugHandler -> DecayDrawCardHandler -> DecayFadeHandler -> DestructionImpulseHandler -> DevotedHandler -> DiscarderHandler -> DominanceHandler -> DrunkenDreamHandler -> DyingHandler -> ElingHandler -> EnvyHandler -> EquipmentTransferHandler -> ExinwanHandler -> ExterminateFadeHandler -> ExterminateHandler -> ExtraCardHandler -> ExtraCardSlotHandler -> ExtremeIntelligenceHandler -> ExtremeIntelligenceKOFHandler -> FerryFeeHandler -> FlyingSkandaHandler -> FoisonHandler -> GodDescendantHandler -> GrimoireHandler -> GuidedDeathHandler -> HeartfeltFancyHandler -> HeavyDrinkerHandler -> HeterodoxyHandler -> IbukiGourdHandler -> IceWingHandler -> IdentityRevealHandler -> ImperishableNightHandler -> JiongyanjianHandler -> JollyHandler -> KOFCharacterSwitchHandler -> KanakoFaithKOFHandler -> KeineGuardHandler -> KeystoneHandler -> KnowledgeHandler -> LibraryHandler -> LittleLegionHandler -> LoongPunchHandler -> LuckHandler -> LunaStringLaunchCardHandler -> LunaticHandler -> MahjongDrugHandler -> MindReadHandler -> MiracleMalletHandler -> MorphingHandler -> NakedFoxHandler -> NitoryuuWearEquipmentHandler -> ProphetHandler -> PsychopathHandler -> QiliaoDropHandler -> QiliaoRecoverHandler -> RebornHandler -> ReimuClearHandler -> RepentanceStickHandler -> ReturningHandler -> ReversalHandler -> ReversedScalesHandler -> RiverBehindHandler -> RiversideHandler -> RosaHandler -> RoukankenEffectHandler -> SanaeFaithKOFHandler -> ScarletMistHandler -> ScarletPerceptionHandler -> SentryHandler -> ShikigamiHandler -> ShipwreckHandler -> ShuffleHandler -> SinsackHatHandler -> SolidShieldHandler -> SoulDrainHandler -> SpiritingAwayHandler -> SummonKOFHandler -> SuwakoHatHandler -> TianyiHandler -> TreasureHuntHandler -> TrialHandler -> TributeHandler -> UFODistanceHandler -> UltimateSpeedHandler -> UmbrellaHandler -> VampireKissHandler -> VengeOfTsukumogamiHandler -> VirtueHandler -> VitalityHandler -> WeaponReforgeHandler -> WindWalkHandler -> XianshizhanHandler -> YinYangOrbHandler -> YoumuHandler -> YoumuPhantomHandler -> CiguateraHandler -> DeathHandler -> DisarmHandler -> ElementalReactorHandler -> FreakingPowerHandler -> HakuroukenHandler -> LaevateinHandler -> LunaDialHandler -> NenshaPhoneHandler -> OpticalCloakHandler -> PerfectCherryBlossomHandler -> PerfectFreezeHandler -> ResonanceHandler -> SadistHandler -> SadistKOFHandler -> SummonHandler -> SupportKOFHandler -> TelegnosisHandler -> AyaRoundfanHandler -> CriticalStrikeHandler -> DecayDamageHandler -> DilemmaHandler -> EchoHandler -> FourOfAKindHandler -> HeritageHandler -> MajestyHandler -> MasochistHandler -> MelancholyHandler -> MomijiShieldHandler -> ReimuExterminateHandler -> HouraiJewelHandler -> MaidenCostumeHandler -> RejectHandler -> SpearTheGungnirHandler -> WineHandler