### PR TITLE
:sparkles: Solve potential bugs in UseCard and Damage with reworked K…

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -47,8 +47,8 @@ else:
 
 
 TESTING_CHARACTERS = (
-    'Koishi',
     'SpSatori',
+    'Koishi',
     'Flandre',
 )
 

--- a/src/thb/actions.py
+++ b/src/thb/actions.py
@@ -440,7 +440,7 @@ class BaseDamage(GenericAction):
 
     def apply_action(self):
         tgt = self.target
-        tgt.life -= self.amount
+        tgt.life -= max(self.amount, 0)
         return True
 
     def is_valid(self):
@@ -528,6 +528,11 @@ class UseCard(GenericAction):
         if act:
             return act(self.target, self.card).can_fire()
         else:
+            try:
+                _ = Game.getgame().emit_event('action_shootdown', self)
+                assert _ is self, "You can't replace action in 'action_shootdown' event!"
+            except ActionShootdown as e:
+                return e
             return True
 
 

--- a/src/thb/cards/spellcard.py
+++ b/src/thb/cards/spellcard.py
@@ -293,8 +293,8 @@ class MapCannonEffect(InstantSpellCardAction):
     def apply_action(self):
         g = Game.getgame()
         source, target = self.source, self.target
-        graze_action = basic.UseGraze(target)
-        if not g.process_action(graze_action):
+        use_action = basic.UseGraze(target)
+        if not g.process_action(use_action):
             g.process_action(Damage(source, target, amount=1))
             return True
         else:

--- a/src/thb/characters/koishi.py
+++ b/src/thb/characters/koishi.py
@@ -4,9 +4,8 @@
 # -- third party --
 # -- own --
 from game.autoenv import EventHandler, Game, user_input
-from thb.actions import Damage, GenericAction, UserAction, migrate_cards
-from thb.cards import Attack, Skill
-from thb.cards import t_None
+from thb.actions import ActionShootdown, Damage, GenericAction, PlayerDeath, PlayerTurn, UserAction, migrate_cards
+from thb.cards import Attack, LaunchCard, Skill, UseCard, VirtualCard, t_None
 from thb.characters.baseclasses import Character, register_character_to
 from thb.inputlets import ChooseOptionInputlet, ChoosePeerCardInputlet
 
@@ -14,7 +13,7 @@ from thb.inputlets import ChooseOptionInputlet, ChoosePeerCardInputlet
 # -- code --
 class Unconsciousness(Skill):
     associated_action = None
-    skill_category = ('character', 'passive')
+    skill_category = ('character', 'passive', 'compulsory')
     target = t_None
 
 
@@ -24,11 +23,12 @@ class UnconsciousnessAction(GenericAction):
         self.source, self.target = act.source, act.target
 
     def apply_action(self):
-        self.action.amount += 1 - 2 * bool(len(self.target.cards) + len(self.target.showncards))
+        if self.action.amount > 0:
+            self.action.amount += -1
         return True
 
 
-class UnconsciousnessHandler(EventHandler):
+class UnconsciousDamageHandler(EventHandler):
     interested = ('action_before',) # active char > weapon > passive char > protection > game-state (wine)
     execute_before = (
         'RepentanceStickHandler',
@@ -44,9 +44,56 @@ class UnconsciousnessHandler(EventHandler):
 
             g = Game.getgame()
             src = act.source
-            if not src or not src.has_skill(Unconsciousness): return act
             tgt = act.target
-            tgt.dead or g.process_action(UnconsciousnessAction(act))
+
+            p = getattr(g, 'current_player', None)
+            if not p or not p.has_skill(Unconsciousness): return act
+
+            if not src or not src.has_skill(Unconsciousness): return act
+
+            len(tgt.cards) + len(tgt.showncards) < tgt.life or tgt.dead or g.process_action(UnconsciousnessAction(act))
+
+        return act
+
+
+class UnconsciousnessLimit(ActionShootdown):
+    pass
+
+
+class UnconsciousSilenceHandler(EventHandler):
+    interested = ('action_shootdown',)
+
+    def handle(self, evt_type, act):
+        if evt_type == 'action_shootdown' and isinstance(act, (LaunchCard, UseCard)):
+            src = act.source
+            tgt = act.target
+
+            if not src or src.has_skill(Unconsciousness): return act
+            if not tgt or tgt.dead: return act
+
+            g = Game.getgame()
+            p = getattr(g, 'current_player', None)
+
+            if not p or not p.has_skill(Unconsciousness): return act
+
+            if len(src.cards) + len(src.showncards) < src.life: return act
+
+            def walk(c):
+                if not c.is_card(VirtualCard):
+                    return [c]
+
+                if c.usage not in ('launch', 'use'):
+                    return []
+
+                cards = c.associated_cards
+                return walk(cards[0]) if len(cards) == 1 else cards
+
+            cards = walk(act.card)
+
+            zone = src.cards, src.showncards, src.equips, src.fatetell, src.special
+            for c in cards:
+                if c.resides_in in zone:
+                    raise UnconsciousnessLimit
 
         return act
 
@@ -74,7 +121,7 @@ class ParanoiaAction(UserAction):
 
 class ParanoiaHandler(EventHandler):
     interested = ('action_after',)
-    execute_before = ( # 2 weapon and 6 passive char
+    execute_before = (
         'AyaRoundfanHandler',
         'NenshaPhoneHandler',
         'DilemmaHandler',
@@ -83,6 +130,7 @@ class ParanoiaHandler(EventHandler):
         'MelancholyHandler',
         'MajestyHandler',
         'MasochistHandler',
+        'ThirdEyeHandler',
     )
 
     execute_after = (
@@ -102,16 +150,38 @@ class ParanoiaHandler(EventHandler):
 
             pact = g.action_stack[-1]
             if isinstance(pact, Attack) and g.current_player is src:
-                src.tags['vitality'] += 1
+                if not src.tags['vitality']:
+                    src.tags['vitality'] += 1
 
-            if user_input([src], ChooseOptionInputlet(self, (False, True))): 
+                # disable skills:
+                tgt.tags['paranoia'] = True
+                for s in tgt.skills:
+                    if 'character' in s.skill_category:
+                        tgt.disable_skill(s, 'paranoia')
+
+            if user_input([src], ChooseOptionInputlet(self, (False, True))):
                 g.process_action(ParanoiaAction(src, tgt))
 
         return act
 
 
+class ParanoiaFadeHandler(EventHandler):
+    interested = ('action_after', 'action_apply')
+
+    def handle(self, evt_type, arg):
+        if ((evt_type == 'action_after' and isinstance(arg, PlayerTurn)) or
+            (evt_type == 'action_apply' and isinstance(arg, PlayerDeath) and arg.target.has_skill(Paranoia))):  # noqa
+
+            g = Game.getgame()
+            for p in g.players:
+                if p.tags.pop('paranoia', ''):
+                    p.reenable_skill('paranoia')
+
+        return arg
+
+
 @register_character_to('common')
 class Koishi(Character):
     skills = [Unconsciousness, Paranoia]
-    eventhandlers_required = [UnconsciousnessHandler, ParanoiaHandler]
+    eventhandlers_required = [UnconsciousDamageHandler, UnconsciousSilenceHandler, ParanoiaHandler, ParanoiaFadeHandler]
     maxlife = 4

--- a/src/thb/ui/ui_meta/characters/koishi.py
+++ b/src/thb/ui/ui_meta/characters/koishi.py
@@ -14,7 +14,7 @@ __metaclass__ = gen_metafunc(characters.koishi)
 
 class Unconsciousness:
     name = u'无我'
-    description = u'|B锁定技|r，你对有手牌的角色造成的伤害-1，对没有手牌的角色造成的伤害+1。'
+    description = u'|B锁定技|r，你的回合内手牌数不小于体力的其他角色不能使用或打出牌，且你对其造成的伤害-1。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid
@@ -30,9 +30,14 @@ class UnconsciousnessAction:
         return ''
 
 
+class UnconsciousnessLimit:
+    target_independent = True
+    shootdown_message = u'【无意识】你的手牌数不小于体力值，不能使用或打出任一张牌'
+
+
 class Paranoia:
     name = u'偏执'
-    description = u'每当你对一名角色造成伤害后，若该伤害恰为0点，你可以获得其一张手牌，该伤害若是|G弹幕|r效果造成的，且当前是你的回合，你额外+1干劲。'
+    description = u'每当你对一名角色造成伤害后，该伤害若是|G弹幕|r效果造成的，直到回合结束时其所有技能失效且你的干劲置为一；若该伤害恰为0点，你可以获得其一张手牌。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid
@@ -68,7 +73,3 @@ class Koishi:
     port_image        = u'thb-portrait-koishi'
     figure_image      = u'thb-figure-koishi'
     miss_sound_effect = u''
-
-
-# As for names for skills, reference:
-# https://en.touhouwiki.net/wiki/Koishi_Komeiji#Spell_Cards


### PR DESCRIPTION
In the past, the UseCard has a self method overriding the `action.can_fire()` which in fact allows almost all kinds of UseGraze or UseAttack to skip the `action_shootdown` event emitter, the `use_action` attribute never really got except that in Eirin's `LunaStringPlaceCard`. Like that in medicine melancholy's poison, the silenced character can still USE attack or graze to counteract under MapCannon or Duel threats. Now this problem is solved, by putting the `action_shootdown` emitter into the overriding `can_fire()` method of all UseCard cls, subcls, and objects, which makes medicine and koishi able to prevent some characters from using cards, just like that in LaunchCard.
This version also prevents any damages which can be numerically negative, like wine, ran playing with koishi (at the will of the designer himself), passing all kinds of local tests and no crashes or bugs are detected yet.