### PR TITLE
:bug: Make Eirin SkySilk play well with Shinmyoumaru

### DIFF
--- a/src/thb/characters/eirin.py
+++ b/src/thb/characters/eirin.py
@@ -29,6 +29,7 @@ class SkySilkAction(UserAction):
         g.players.reveal(c)
 
         g.process_action(DropCards(src, tgt, [c]))
+        if tgt.dead: return False
 
         action = 'draw'
         if tgt.life < tgt.maxlife:


### PR DESCRIPTION
It is obvious that once Eirin tries to heal or help 1 HP characters opposing Shinmyoumaru, a probably fallen character will see the button of heal or draw. This has been prevented, owing to user complaints.