### PR TITLE
:bug: Fix Nitori Craftsman double or more launching graze or heal

### DIFF
--- a/src/thb/characters/nitori.py
+++ b/src/thb/characters/nitori.py
@@ -4,7 +4,7 @@
 # -- third party --
 # -- own --
 from game.autoenv import Game, user_input
-from thb.actions import ActionLimitExceeded, ActionStageLaunchCard, DrawCards, EventHandler
+from thb.actions import ActionLimitExceeded, DrawCards, EventHandler, LaunchCard
 from thb.actions import Reforge, UserAction, random_choose_card, ttags
 from thb.cards import AttackCard, Card, Skill, TreatAs, t_OtherOne
 from thb.characters.baseclasses import Character, register_character_to
@@ -69,17 +69,17 @@ class CraftsmanHandler(EventHandler):
     interested = ('action_after', 'action_shootdown')
 
     def handle(self, evt_type, act):
-        if evt_type == 'action_after' and isinstance(act, ActionStageLaunchCard):
+        if evt_type == 'action_after' and isinstance(act, LaunchCard):
             c = act.card
             if c.is_card(Craftsman):
                 src = act.source
                 ttags(src)['craftsman'] = True
 
         elif evt_type == 'action_shootdown':
-            if not isinstance(act, ActionStageLaunchCard): return act
+            if not isinstance(act, LaunchCard): return act
             c = act.card
             if not c.is_card(Craftsman): return act
-            if ttags(act.source)['craftsman']:
+            if ttags(act.source)['craftsman'] and Game.getgame().current_player is act.source:
                 raise ActionLimitExceeded
 
         return act

--- a/src/thb/ui/ui_meta/characters/nitori.py
+++ b/src/thb/ui/ui_meta/characters/nitori.py
@@ -43,7 +43,7 @@ class Dismantle:
 
 class Craftsman:
     name = u'匠心'
-    description = u'你可以将你的全部手牌（至少1张）当做任意的一张基本牌使用或打出。出牌阶段内使用时，一回合限一次。'
+    description = u'你可以将你的全部手牌（至少1张）当做任意的一张基本牌使用或打出。你的回合以此方式使用牌时，一回合限一次。'
 
     params_ui = 'UICraftsmanCardSelection'
 


### PR DESCRIPTION
No local crashes or bugs.
Checking in BusinessLogicLayer and UserInterfaceLayer both to counter tagons.

(PS: I do not like one eventListener listening on multi events especially when the ehs themselves need an incomplete sorting map)