### PR TITLE
:bug: Fix Koishi-related launch attack problem and Seiga Unconsciousn…

### DIFF
--- a/src/thb/characters/koishi.py
+++ b/src/thb/characters/koishi.py
@@ -90,10 +90,8 @@ class UnconsciousSilenceHandler(EventHandler):
 
             cards = walk(act.card)
 
-            zone = src.cards, src.showncards, src.equips, src.fatetell, src.special
-            for c in cards:
-                if c.resides_in in zone:
-                    raise UnconsciousnessLimit
+            if cards: # no matter where it resides in, even if others (i.e. puppeteer Seiga having Unconsciousness)
+                raise UnconsciousnessLimit
 
         return act
 

--- a/src/thb/characters/momiji.py
+++ b/src/thb/characters/momiji.py
@@ -104,6 +104,10 @@ class SentryAction(AskForCard):
         c = SentryAttack.wrap([c], src)
         return g.process_action(LaunchCard(src, [tgt], c))
 
+    def ask_for_action_verify(self, p, cl, tl):
+        src, tgt = self.source, self.victim
+        return LaunchCard(src, [tgt], cl[0]).can_fire()
+
 
 class SentryHandler(EventHandler):
     interested = ('action_apply',)

--- a/src/thb/characters/reimu.py
+++ b/src/thb/characters/reimu.py
@@ -158,6 +158,10 @@ class ReimuExterminateAction(AskForCard):
         g = Game.getgame()
         return g.process_action(ReimuExterminateLaunchCard(self.source, self.victim, c, self.cause))
 
+    def ask_for_action_verify(self, p, cl, tl):
+        src, tgt = self.source, self.victim
+        return ReimuExterminateLaunchCard(src, tgt, cl[0], self.cause).can_fire()
+
 
 class ReimuExterminateHandler(EventHandler):
     interested = ('action_apply', 'action_after')


### PR DESCRIPTION
恋恋的实现，反过来查出了潜在的旧问题：
1 - 打出卡牌跳过shootdown询问，和荷取、梅花欣有关，已消除。
2 - 缴械、退治的使用弹幕跳过询问，导致“无我”沉默计算时，业务逻辑和界面失调，已彻底消除。
新问题：
3 - 娘娘获得无我，而后以人身份使用卡牌，之前未计入，现已计入无我的沉默流程。

悠子已提出恋恋的设计可以实装。

恋恋的实装还差2个cv和2个图标。
一个是“偏执”图标（投稿人id“真炎的爆发”自画的“妖怪测谎机”，用于标明该角色之技能暂时无效化），另一个是干劲重置图标（也许可以没有）。
浪费了两个图标，芙兰的“狂咲”和“毁灭”。
