### PR TITLE
:sparkles: Koishi slight tune permitting UseCard in Unconsciousness

### DIFF
--- a/src/thb/characters/koishi.py
+++ b/src/thb/characters/koishi.py
@@ -5,7 +5,7 @@
 # -- own --
 from game.autoenv import EventHandler, Game, user_input
 from thb.actions import ActionShootdown, Damage, GenericAction, PlayerDeath, PlayerTurn, UserAction, migrate_cards
-from thb.cards import Attack, LaunchCard, Skill, UseCard, VirtualCard, t_None
+from thb.cards import Attack, LaunchCard, Skill, VirtualCard, t_None
 from thb.characters.baseclasses import Character, register_character_to
 from thb.inputlets import ChooseOptionInputlet, ChoosePeerCardInputlet
 
@@ -64,7 +64,7 @@ class UnconsciousSilenceHandler(EventHandler):
     interested = ('action_shootdown',)
 
     def handle(self, evt_type, act):
-        if evt_type == 'action_shootdown' and isinstance(act, (LaunchCard, UseCard)):
+        if evt_type == 'action_shootdown' and isinstance(act, LaunchCard):
             src = act.source
             tgt = act.target
 
@@ -82,7 +82,7 @@ class UnconsciousSilenceHandler(EventHandler):
                 if not c.is_card(VirtualCard):
                     return [c]
 
-                if c.usage not in ('launch', 'use'):
+                if c.usage not in ('launch',):
                     return []
 
                 cards = c.associated_cards

--- a/src/thb/ui/ui_meta/characters/koishi.py
+++ b/src/thb/ui/ui_meta/characters/koishi.py
@@ -14,7 +14,7 @@ __metaclass__ = gen_metafunc(characters.koishi)
 
 class Unconsciousness:
     name = u'无我'
-    description = u'|B锁定技|r，你的回合内手牌数不小于体力的其他角色不能使用或打出牌，且你对其造成的伤害-1。'
+    description = u'|B锁定技|r，你的回合内手牌数不小于体力的其他角色不能使用任一张牌，且你对其造成的伤害-1。'
 
     clickable = passive_clickable
     is_action_valid = passive_is_action_valid
@@ -29,7 +29,7 @@ class UnconsciousnessAction:
 
 class UnconsciousnessLimit:
     target_independent = True
-    shootdown_message = u'【无意识】你的手牌数不小于体力值，不能使用或打出任一张牌'
+    shootdown_message = u'【无意识】你的手牌数不小于体力值，不能使用任一张牌'
 
 
 class Paranoia:


### PR DESCRIPTION
说好了的临场又调……亏得它之前还反向查出了`UseCard`的`can_fire()`存在问题并且改过来的说……（现在自然是没有用了，不过把荷取和梅花欣的潜在问题提前解决了）
原因是“防止开局群体符卡后迅速强大”的失衡。