### PR TITLE
:bug: Remilia Spear order tuned before HouraiJewel and other weapons

### DIFF
--- a/src/thb/characters/remilia.py
+++ b/src/thb/characters/remilia.py
@@ -31,11 +31,9 @@ class SpearTheGungnirAction(GenericAction):
 
 class SpearTheGungnirHandler(EventHandler):
     interested = ('action_before',)
-    execute_before = ('ScarletRhapsodySwordHandler', )
-    execute_after = (
-        'HakuroukenEffectHandler',
-        'HouraiJewelHandler',
-    )
+    execute_before = ('ScarletRhapsodySwordHandler',
+                      'HouraiJewelHandler',
+                      'HakuroukenHandler')
 
     def handle(self, evt_type, act):
         if evt_type == 'action_before' and isinstance(act, Attack):


### PR DESCRIPTION
As is reported among the complaints on a multi-mixed class of action `Attack` which results in a conflict when a user adopts the method of both `RemiliaSpear` and `HouraiJewel` then even a Rejected Jewel attack can cause two HP damage of Wined Spear. The truth is once a Jewel modified spear is chosen to be launched, there is only Jewel effect left.
Also this is a problem on order of events: `chara > equip`.
Modified.