### PR TITLE
:speech_balloon: Correct Mamizou Morphing UI string to unicode

### DIFF
--- a/src/thb/ui/inputs.py
+++ b/src/thb/ui/inputs.py
@@ -1014,10 +1014,10 @@ class UIMorphingCardSelection(CardSelectionPanel):
         card_lists = []
 
         l = [c for c in cards if 'basic' in c.category]
-        l and card_lists.append(('基本牌', l))
+        l and card_lists.append((u'基本牌', l))
 
         l = [c for c in cards if 'instant_spellcard' in c.category]
-        l and card_lists.append(('符卡', l))
+        l and card_lists.append((u'符卡', l))
 
         self.selection_mode = CardSelectionPanel.SINGLE
         self.init(card_lists, multiline=len(card_lists) < 2)


### PR DESCRIPTION
For a long time the UI prompt string of `Morphing` has stayed unable to read in Chinese, for in py ver2 only `u'...'` can show correct words; even though it does not really matter in py ver3 whether it is prefixed with `u` or not, it seems that the old version may have to correct the last mistake of unicode of all strings in order to maintain the coding coordination. (>_<)