### PR TITLE
:bug: InsightfulSword UseCard detachment restored

### DIFF
--- a/src/thb/characters/sp_youmu.py
+++ b/src/thb/characters/sp_youmu.py
@@ -45,6 +45,14 @@ class InsightfulSwordGrazeAction(UserAction):
         tgt, card = self.target, self.card
         return Game.getgame().process_action(LaunchCard(tgt, [tgt], card))
 
+    def is_valid(self):
+        tgt, card = self.target, self.card
+        return LaunchCard(tgt, [tgt], card).can_fire()
+
+    def ask_for_action_verify(self, p, cl, tl):
+        tgt, card = self.target, cl[0]
+        return LaunchCard(tgt, [tgt], card).can_fire()
+
 
 class InsightfulSwordDamageAction(UserAction):
 
@@ -62,6 +70,9 @@ class InsightfulSwordMixin(AskForCard):
         g = Game.getgame()
         if not card.is_card(GrazeCard):
             tgt = self.target
+            card.move_to(tgt.cards) # shall not be detached yet, yet detached already, when AskForCard -> UseGraze -> ...
+            assert card.usage == 'launch'
+
             if not g.process_action(InsightfulSwordGrazeAction(tgt, tgt, card)):
                 return False
             if not tgt.has_skill(InsightfulSword): # fall when wearing weapon


### PR DESCRIPTION
FIrst bug oriented from the classmix. Koishi `Unconscience` encounters with `InsightfulSword` and when it comes to `UseGraze` when responding to `MapCannon`, according to description, Youmu shall not launch weapon to use a virtual graze, however in former implementation code she can. Bug.
To find the reason, the length of Youmu's cardlist is printed, in which the weapon card detached unintentionally, resulting in the length of her handcard list underestimated by 1. When it comes to `AskForCard`, it seems the weapon is detached before calculating wearing it.
As a solution, the weapon selected to be launched is moved back into her handcards after responding to `MapCannon`, before wearing equips.